### PR TITLE
support mocking time.Sleep, add trap.Direct

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,6 +42,6 @@ jobs:
 
     - name: Check spelling of files
       uses: crate-ci/typos@master
-      continue-on-error: true
+      continue-on-error: false
       with: 
         files: ./

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -3,8 +3,8 @@ package main
 import "fmt"
 
 const VERSION = "1.0.15"
-const REVISION = "05e21215595deccfc08d49cb2d502e0d48b3cf4b+1"
-const NUMBER = 151
+const REVISION = "2861a46387df90bcadae7651dc6e0d2db8ab0148+1"
+const NUMBER = 152
 
 func getRevision() string {
 	return fmt.Sprintf("%s %s BUILD_%d", VERSION, REVISION, NUMBER)

--- a/patch/syntax/rewrite.go
+++ b/patch/syntax/rewrite.go
@@ -41,6 +41,10 @@ func rewriteStdAndGenericFuncs(funcDecls []*DeclInfo, pkgPath string) {
 		if fn.Closure {
 			continue
 		}
+		if fn.FuncDecl.Body == nil {
+			// no body, may be linked
+			continue
+		}
 
 		// stdlib and generic
 		if !base.Flag.Std {
@@ -48,7 +52,6 @@ func rewriteStdAndGenericFuncs(funcDecls []*DeclInfo, pkgPath string) {
 				continue
 			}
 		}
-
 		fnDecl := fn.FuncDecl
 		pos := fn.FuncDecl.Pos()
 

--- a/patch/syntax/syntax.go
+++ b/patch/syntax/syntax.go
@@ -255,7 +255,7 @@ func shouldTrap() bool {
 	}
 
 	pkgPath := xgo_ctxt.GetPkgPath()
-	if pkgPath == "" || pkgPath == "runtime" || strings.HasPrefix(pkgPath, "runtime/") || strings.HasPrefix(pkgPath, "internal/") || isSkippableSpecialPkg() {
+	if pkgPath == "" || strings.HasPrefix(pkgPath, "runtime/") || strings.HasPrefix(pkgPath, "internal/") || isSkippableSpecialPkg() {
 		// runtime/internal should not be rewritten
 		// internal/api has problem with the function register
 		return false

--- a/patch/trap.go
+++ b/patch/trap.go
@@ -301,6 +301,11 @@ func CanInsertTrapOrLink(fn *ir.Func) (string, bool) {
 		return linkName, false
 		// ir.Dump("after:", fn)
 	}
+	// disable all stdlib IR rewrite
+	if base.Flag.Std {
+		// NOTE: stdlib are rewritten by source
+		return "", false
+	}
 	if xgo_ctxt.SkipPackageTrap() {
 		return "", false
 	}
@@ -336,12 +341,6 @@ func CanInsertTrapOrLink(fn *ir.Func) (string, bool) {
 
 	// check if function body's first statement is a call to 'trap.Skip()'
 	if isFirstStmtSkipTrap(fn.Body) {
-		return "", false
-	}
-
-	// disable part of stdlibs
-	if base.Flag.Std {
-		// NOTE: stdlib are rewritten by source
 		return "", false
 	}
 

--- a/runtime/core/version.go
+++ b/runtime/core/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 const VERSION = "1.0.15"
-const REVISION = "05e21215595deccfc08d49cb2d502e0d48b3cf4b+1"
-const NUMBER = 151
+const REVISION = "2861a46387df90bcadae7651dc6e0d2db8ab0148+1"
+const NUMBER = 152
 
 // these fields will be filled by compiler
 const XGO_VERSION = ""

--- a/runtime/mock/stdlib.md
+++ b/runtime/mock/stdlib.md
@@ -9,9 +9,12 @@ So only a limited list of stdlib functions can be mocked. However, if there lack
 ## `os`
 - `Getenv`
 - `Getwd`
+- `OpenFile`
 
 ## `time`
 - `Now`
+- `Sleep`
+- `NewTicker`
 - `Time.Format`
 
 ## `os/exec`
@@ -34,3 +37,56 @@ So only a limited list of stdlib functions can be mocked. However, if there lack
 - `DialUDP`
 - `DialUnix`
 - `DialTimeout`
+
+
+# Examples
+> Check [../test/mock_stdlib/mock_stdlib_test.go](../test/mock_stdlib/mock_stdlib_test.go) for more details.
+```go
+package mock_stdlib
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xhd2015/xgo/runtime/core"
+	"github.com/xhd2015/xgo/runtime/mock"
+)
+
+func TestMockTimeSleep(t *testing.T) {
+	begin := time.Now()
+	sleepDur := 1 * time.Second
+	var haveCalledMock bool
+	var mockArg time.Duration
+	mock.Mock(time.Sleep, func(ctx context.Context, fn *core.FuncInfo, args, results core.Object) error {
+		haveCalledMock = true
+		mockArg = args.GetFieldIndex(0).Value().(time.Duration)
+		return nil
+	})
+	time.Sleep(sleepDur)
+
+	// 37.275µs
+	cost := time.Since(begin)
+
+	if !haveCalledMock {
+		t.Fatalf("expect haveCalledMock, actually not")
+	}
+	if mockArg != sleepDur {
+		t.Fatalf("expect mockArg to be %v, actual: %v", sleepDur, mockArg)
+	}
+	if cost > 100*time.Millisecond {
+		t.Fatalf("expect time.Sleep mocked, actual cost: %v", cost)
+	}
+}
+```
+
+Run:`xgo test -v ./`
+Output:
+```sh
+=== RUN   TestMockTimeSleep
+--- PASS: TestMockTimeSleep (0.00s)
+PASS
+ok      github.com/xhd2015/xgo/runtime/test/mock_stdlib 0.725s
+```
+
+Note we call `time.Sleep` with `1s`, but it returns within few micro-seconds.

--- a/runtime/test/func_list/func_list_stdlib_test.go
+++ b/runtime/test/func_list/func_list_stdlib_test.go
@@ -21,11 +21,14 @@ func TestListStdlib(t *testing.T) {
 
 	stdPkgs := map[string]bool{
 		// os
-		"os.Getenv": true,
-		"os.Getwd":  true,
+		"os.Getenv":   true,
+		"os.Getwd":    true,
+		"os.OpenFile": true,
 
 		// time
 		"time.Now":         true,
+		"time.Sleep":       true,
+		"time.NewTicker":   true,
 		"time.Time.Format": true,
 
 		// exec

--- a/runtime/test/trap/trap_direct_test.go
+++ b/runtime/test/trap/trap_direct_test.go
@@ -1,0 +1,43 @@
+package trap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/core"
+	"github.com/xhd2015/xgo/runtime/trap"
+)
+
+func TestDirectShouldByPassTrap(t *testing.T) {
+	trap.AddInterceptor(&trap.Interceptor{
+		Pre: func(ctx context.Context, f *core.FuncInfo, args, result core.Object) (data interface{}, err error) {
+			if f.IdentityName == "direct" {
+				panic("direct should be bypassed")
+			}
+			if f.IdentityName == "nonByPass" {
+				result.GetFieldIndex(0).Set("mock nonByPass")
+				return nil, trap.ErrAbort
+			}
+			return nil, nil
+		},
+	})
+	var resDirect string
+	trap.Direct(func() {
+		resDirect = direct()
+	})
+	if resDirect != "direct" {
+		t.Fatalf("expect direct() to be %q, actual: %q", "direct", resDirect)
+	}
+
+	nonRes := nonByPass()
+	if nonRes != "mock nonByPass" {
+		t.Fatalf("expect nonByPass() to be %q, actual: %q", "mock nonByPass", nonRes)
+	}
+}
+
+func direct() string {
+	return "direct"
+}
+func nonByPass() string {
+	return "nonByPass"
+}

--- a/runtime/trap/direct.go
+++ b/runtime/trap/direct.go
@@ -1,0 +1,20 @@
+package trap
+
+import "sync"
+
+var bypassMapping sync.Map // <goroutine key> -> struct{}{}
+
+// Direct make a call to fn, without
+// any trap and mock interceptors
+func Direct(fn func()) {
+	key := uintptr(__xgo_link_getcurg())
+	bypassMapping.Store(key, struct{}{})
+	defer bypassMapping.Delete(key)
+	fn()
+}
+
+func isByPassing() bool {
+	key := uintptr(__xgo_link_getcurg())
+	_, ok := bypassMapping.Load(key)
+	return ok
+}

--- a/runtime/trap/inspect.go
+++ b/runtime/trap/inspect.go
@@ -12,7 +12,7 @@ import (
 
 const methodSuffix = "-fm"
 
-// Inspect make a call to f to capture its receiver pointer if is
+// Inspect make a call to f to capture its receiver pointer if it
 // is bound method
 // It can be used to get the unwrapped innermost function of a method
 // wrapper.

--- a/runtime/trap/interceptor.go
+++ b/runtime/trap/interceptor.go
@@ -155,6 +155,7 @@ type interceptorList struct {
 func clearLocalInterceptorsAndMark() {
 	key := uintptr(__xgo_link_getcurg())
 	localInterceptors.Delete(key)
+	bypassMapping.Delete(key)
 
 	clearTrappingMark()
 }

--- a/runtime/trap/trap.go
+++ b/runtime/trap/trap.go
@@ -20,6 +20,9 @@ func ensureTrapInstall() {
 }
 func init() {
 	__xgo_link_on_gonewproc(func(g uintptr) {
+		if isByPassing() {
+			return
+		}
 		interceptors := GetLocalInterceptors()
 		if len(interceptors) == 0 {
 			return
@@ -55,6 +58,9 @@ var trappingPC sync.Map   // <gorotuine key> -> PC
 // link to runtime
 // xgo:notrap
 func trapImpl(pkgPath string, identityName string, generic bool, pc uintptr, recv interface{}, args []interface{}, results []interface{}) (func(), bool) {
+	if isByPassing() {
+		return nil, false
+	}
 	dispose := setTrappingMark()
 	if dispose == nil {
 		return nil, false


### PR DESCRIPTION
Addressing https://github.com/xhd2015/xgo/issues/18#issuecomment-2031498831 :
> they use gomonkey to mock these stdlib APIs: time.NewTicker, syscall.Kill, os.OpenFile,file.WriteAt,file.Sync, file.Close