### PR TITLE
fix sub test traces

### DIFF
--- a/cmd/xgo/help.go
+++ b/cmd/xgo/help.go
@@ -10,9 +10,9 @@ Usage:
     xgo <command> [arguments]
 
 The commands are:
-    build       build instrumented code, extra arguments are passed 'go build' verbatim
-    run         run instrumented code, extra arguments are passed 'go run' verbatim
-    test        test instrumented code, extra arguments are passed 'go test' verbatim
+    build       build instrumented code, extra arguments are passed to 'go build' verbatim
+    run         run instrumented code, extra arguments are passed to 'go run' verbatim
+    test        test instrumented code, extra arguments are passed to 'go test' verbatim
     exec        execute a command verbatim
     version     print xgo version
     revision    print xgo revision

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -2,9 +2,9 @@ package main
 
 import "fmt"
 
-const VERSION = "1.0.23"
-const REVISION = "e8daf6b3b430f0be7a30aa02bf0f8334c93537ec+1"
-const NUMBER = 178
+const VERSION = "1.0.24"
+const REVISION = "b70bf6dce3af4317cb6a3b2b18dc30e2b36b8afa+1"
+const NUMBER = 179
 
 func getRevision() string {
 	revSuffix := ""

--- a/runtime/core/version.go
+++ b/runtime/core/version.go
@@ -6,9 +6,9 @@ import (
 	"os"
 )
 
-const VERSION = "1.0.23"
-const REVISION = "e8daf6b3b430f0be7a30aa02bf0f8334c93537ec+1"
-const NUMBER = 178
+const VERSION = "1.0.24"
+const REVISION = "b70bf6dce3af4317cb6a3b2b18dc30e2b36b8afa+1"
+const NUMBER = 179
 
 // these fields will be filled by compiler
 const XGO_VERSION = ""

--- a/runtime/test/trace_marshal/with_subtests/trace_with_subtests_test.go
+++ b/runtime/test/trace_marshal/with_subtests/trace_with_subtests_test.go
@@ -1,0 +1,41 @@
+package trace_marshal_with_trace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/trace"
+)
+
+func TestMarshalWithTrace(t *testing.T) {
+	const N = 10
+	traces := make([]*trace.Root, N)
+	for i := 0; i < 10; i++ {
+		i := i
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			finish := trace.Options().OnComplete(func(root *trace.Root) {
+				traces[i] = root
+			}).Begin()
+			defer finish()
+			res := foo(i)
+
+			expect := fmt.Sprintf("foo bar_%d", i)
+			if res != expect {
+				t.Fatalf("expect %q, actual: %q", expect, res)
+			}
+		})
+	}
+	// each should have children
+	for i, tr := range traces {
+		if len(tr.Children) != 1 {
+			t.Fatalf("expect traces[%d] children len to be %d, actual: %d", i, 1, len(tr.Children))
+		}
+	}
+}
+
+func foo(i int) string {
+	return "foo " + bar(i)
+}
+func bar(i int) string {
+	return fmt.Sprintf("bar_%d", i)
+}


### PR DESCRIPTION
When running multiple tests, only the first test gets it's full trace.

That's because when installing the trace interceptor, we set a flag to avoid duplicate, but do not remove that flag after cancelling the interceptor.

By the way, I find that trace can be simply enabled via:
```go
defer trace.Begin()()
```