### PR TITLE
make xgo can run anywhere

### DIFF
--- a/cmd/xgo/main.go
+++ b/cmd/xgo/main.go
@@ -343,7 +343,10 @@ func handleBuild(cmd string, args []string) error {
 	var toolExecFlag string
 	if !noInstrument {
 		logDebug("build instrument tools: %s", instrumentGoroot)
-		xgoBin := os.Args[0]
+		xgoBin, err := filepath.Abs(os.Args[0])
+		if err != nil {
+			return err
+		}
 		compilerChanged, toolExecFlag, err = buildInstrumentTool(instrumentGoroot, realXgoSrc, compilerBin, compilerBuildID, "", xgoBin, debug, logCompile, noSetup, debugWithDlv)
 		if err != nil {
 			return err

--- a/cmd/xgo/runtime_gen/core/version.go
+++ b/cmd/xgo/runtime_gen/core/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 const VERSION = "1.0.36"
-const REVISION = "1e1b9419279db2f75b8619256fced2e8a84e9ee7+1"
-const NUMBER = 229
+const REVISION = "48d5fefe9c2c051c940e088429f9253b80a65305+1"
+const NUMBER = 230
 
 // these fields will be filled by compiler
 const XGO_VERSION = ""

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -3,8 +3,8 @@ package main
 import "fmt"
 
 const VERSION = "1.0.36"
-const REVISION = "1e1b9419279db2f75b8619256fced2e8a84e9ee7+1"
-const NUMBER = 229
+const REVISION = "48d5fefe9c2c051c940e088429f9253b80a65305+1"
+const NUMBER = 230
 
 func getRevision() string {
 	revSuffix := ""

--- a/runtime/core/version.go
+++ b/runtime/core/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 const VERSION = "1.0.36"
-const REVISION = "1e1b9419279db2f75b8619256fced2e8a84e9ee7+1"
-const NUMBER = 229
+const REVISION = "48d5fefe9c2c051c940e088429f9253b80a65305+1"
+const NUMBER = 230
 
 // these fields will be filled by compiler
 const XGO_VERSION = ""


### PR DESCRIPTION
When run xgo in relative style like ./xgo, and the cwd is not in PATH，then toolexec will failed to find the ./xgo.