### PR TITLE
Use a local directory to prevent the issue of cross-device links

### DIFF
--- a/cmd/xgo/runtime_gen/core/version.go
+++ b/cmd/xgo/runtime_gen/core/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 const VERSION = "1.0.37"
-const REVISION = "5009615738fb02321f124776178716796d32c0b7+1"
-const NUMBER = 244
+const REVISION = "2e709f7b1620aea78fdc1dba282bcf6778dd6d51+1"
+const NUMBER = 245
 
 // these fields will be filled by compiler
 const XGO_VERSION = ""

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -3,8 +3,8 @@ package main
 import "fmt"
 
 const VERSION = "1.0.37"
-const REVISION = "5009615738fb02321f124776178716796d32c0b7+1"
-const NUMBER = 244
+const REVISION = "2e709f7b1620aea78fdc1dba282bcf6778dd6d51+1"
+const NUMBER = 245
 
 func getRevision() string {
 	revSuffix := ""

--- a/runtime/core/version.go
+++ b/runtime/core/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 const VERSION = "1.0.37"
-const REVISION = "5009615738fb02321f124776178716796d32c0b7+1"
-const NUMBER = 244
+const REVISION = "2e709f7b1620aea78fdc1dba282bcf6778dd6d51+1"
+const NUMBER = 245
 
 // these fields will be filled by compiler
 const XGO_VERSION = ""

--- a/script/build-release/main.go
+++ b/script/build-release/main.go
@@ -271,15 +271,15 @@ func buildBinaryRelease(dir string, srcDir string, version string, goos string, 
 	if err != nil {
 		return err
 	}
-	tmpDir, err := os.MkdirTemp("", "xgo-release")
+	tmpDir, err := os.MkdirTemp(".", "xgo-release")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
 
 	exeSuffix := osinfo.EXE_SUFFIX
-
-	archive := filepath.Join(tmpDir, "archive")
+	//
+	archive, _ := filepath.Abs(filepath.Join(tmpDir, "archive"))
 
 	bins := [][2]string{
 		{"xgo", "./cmd/xgo"},
@@ -362,7 +362,6 @@ func buildBinaryRelease(dir string, srcDir string, version string, goos string, 
 	if err != nil {
 		return err
 	}
-
 	// mv the release to dir
 	targetArchive := filepath.Join(dir, fmt.Sprintf("xgo%s-%s-%s.tar.gz", version, goos, goarch))
 	err = os.Rename(archive, targetArchive)


### PR DESCRIPTION
A minor adjustment: utilizing a local directory to circumvent the cross-device link complication.
On my Linux system, the /tmp directory and user directory do not belong to the same file system. This setup triggers a cross-device link error in os.Rename.
While I observe that the author has amended parts of os.MkdirTemp(".", xx), the issue with build-release persisted. This has necessitated its repair.