### PR TITLE
fix trace interceptor canceling

### DIFF
--- a/cmd/xgo/runtime_gen/mock/patch.go
+++ b/cmd/xgo/runtime_gen/mock/patch.go
@@ -158,7 +158,15 @@ func buildInterceptorFromPatch(recvPtr interface{}, replacer interface{}) func(c
 		dst := 0
 
 		if fn.RecvType != "" {
+			var isInstance bool
 			if recvPtr != nil {
+				if fn.Generic && trap.GenericImplIsClosure && args.NumField() == nIn {
+					// not an instance
+				} else {
+					isInstance = true
+				}
+			}
+			if isInstance {
 				// patching an instance method
 				src++
 				// replacer's does not have receiver

--- a/cmd/xgo/runtime_gen/trap/interceptor.go
+++ b/cmd/xgo/runtime_gen/trap/interceptor.go
@@ -51,6 +51,10 @@ func AddInterceptor(interceptor *Interceptor) func() {
 	return addInterceptor(nil, interceptor, false)
 }
 
+func AddInterceptorHead(interceptor *Interceptor) func() {
+	return addInterceptor(nil, interceptor, true)
+}
+
 // AddFuncInterceptor add func interceptor, allowing f to be re-entrant
 func AddFuncInterceptor(f interface{}, interceptor *Interceptor) func() {
 	_, fnInfo, pc, _ := InspectPC(f)
@@ -65,10 +69,6 @@ func AddFuncInfoInterceptor(f *core.FuncInfo, interceptor *Interceptor) func() {
 		panic(fmt.Errorf("func cannot be nil"))
 	}
 	return addInterceptor(f, interceptor, false)
-}
-
-func AddInterceptorHead(interceptor *Interceptor) func() {
-	return addInterceptor(nil, interceptor, true)
 }
 
 // WithInterceptor executes given f with interceptor

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // auto updated
 const VERSION = "1.0.41"
-const REVISION = "821b11a349149737249ea29e8c31c7ba8c2ef6e3+1"
-const NUMBER = 273
+const REVISION = "072c1992e76266b4acd75c6c172651763d1ed4fa+1"
+const NUMBER = 274
 
 // manually updated
 const CORE_VERSION = "1.0.41"

--- a/runtime/mock/patch.go
+++ b/runtime/mock/patch.go
@@ -158,7 +158,15 @@ func buildInterceptorFromPatch(recvPtr interface{}, replacer interface{}) func(c
 		dst := 0
 
 		if fn.RecvType != "" {
+			var isInstance bool
 			if recvPtr != nil {
+				if fn.Generic && trap.GenericImplIsClosure && args.NumField() == nIn {
+					// not an instance
+				} else {
+					isInstance = true
+				}
+			}
+			if isInstance {
 				// patching an instance method
 				src++
 				// replacer's does not have receiver

--- a/runtime/test/debug/debug_test.go
+++ b/runtime/test/debug/debug_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/xhd2015/xgo/runtime/mock"
 )
 
+// see bug https://github.com/xhd2015/xgo/issues/211
 type GenericSt[T any] struct {
 	Data T
 }
@@ -26,14 +27,13 @@ func (g GenericSt[T]) GetData(param T) T {
 type Inner struct {
 }
 
-func TestGeneric(t *testing.T) {
-	v := GenericSt[Inner]{}
-
+func TestNonPrimitiveGenericAllInstance(t *testing.T) {
 	var mocked bool
-	mock.Patch(v.GetData, func(Inner) Inner {
+	mock.Patch(GenericSt[Inner].GetData, func(GenericSt[Inner], Inner) Inner {
 		mocked = true
 		return Inner{}
 	})
+	v := GenericSt[Inner]{}
 	v.GetData(Inner{})
 	if !mocked {
 		t.Fatalf("expected mocked, actually not")

--- a/runtime/test/mock_generic/non_primitive_generic_test.go
+++ b/runtime/test/mock_generic/non_primitive_generic_test.go
@@ -31,3 +31,16 @@ func TestNonPrimitiveGeneric(t *testing.T) {
 		t.Fatalf("expected mocked, actually not")
 	}
 }
+
+func TestNonPrimitiveGenericAllInstance(t *testing.T) {
+	var mocked bool
+	mock.Patch(GenericSt[Inner].GetData, func(GenericSt[Inner], Inner) Inner {
+		mocked = true
+		return Inner{}
+	})
+	v := GenericSt[Inner]{}
+	v.GetData(Inner{})
+	if !mocked {
+		t.Fatalf("expected mocked, actually not")
+	}
+}

--- a/runtime/trap/interceptor.go
+++ b/runtime/trap/interceptor.go
@@ -51,6 +51,10 @@ func AddInterceptor(interceptor *Interceptor) func() {
 	return addInterceptor(nil, interceptor, false)
 }
 
+func AddInterceptorHead(interceptor *Interceptor) func() {
+	return addInterceptor(nil, interceptor, true)
+}
+
 // AddFuncInterceptor add func interceptor, allowing f to be re-entrant
 func AddFuncInterceptor(f interface{}, interceptor *Interceptor) func() {
 	_, fnInfo, pc, _ := InspectPC(f)
@@ -65,10 +69,6 @@ func AddFuncInfoInterceptor(f *core.FuncInfo, interceptor *Interceptor) func() {
 		panic(fmt.Errorf("func cannot be nil"))
 	}
 	return addInterceptor(f, interceptor, false)
-}
-
-func AddInterceptorHead(interceptor *Interceptor) func() {
-	return addInterceptor(nil, interceptor, true)
 }
 
 // WithInterceptor executes given f with interceptor


### PR DESCRIPTION
It is observed some times trace can be missing, the debug result shows during request the goroutine gets 0 interceptors, while it is expected to get the trace interceptor.

This is due to the incorrect logic in setting up and cancelling interceptors, it causes interceptor to be canceled while there is some one using it.