### PR TITLE
fix windows suffix error

### DIFF
--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -7,8 +7,8 @@ import "fmt"
 // VERSION is manually updated when needed a new tag
 // if you did not install git hooks, you can manually update them
 const VERSION = "1.1.14"
-const REVISION = "0af20d1a52676c97158307f104c1a6affcca2880+1"
-const NUMBER = 456
+const REVISION = "c4ed3f4f24754c56cccdc187b43d0a54808ff3a6+1"
+const NUMBER = 457
 
 // Rationale: xgo consists of these modules:
 //

--- a/script/download-go/main.go
+++ b/script/download-go/main.go
@@ -209,56 +209,56 @@ func unzip(zipFile string, targetDir string) error {
 	defer r.Close()
 
 	for _, f := range r.File {
-		name := filepath.Clean(f.Name)
-		fullPath := filepath.Join(targetDir, name)
-		rel, err := filepath.Rel(targetDir, fullPath)
-		if err != nil {
+		if err := unzipFile(f, targetDir); err != nil {
 			return err
 		}
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return fmt.Errorf("zip entry escapes target dir: %s", f.Name)
-		}
+	}
+	return nil
+}
 
-		if f.FileInfo().IsDir() {
-			err = os.MkdirAll(fullPath, 0755)
-			if err != nil {
-				return err
-			}
-			continue
-		}
+func unzipFile(f *zip.File, targetDir string) (err error) {
+	name := filepath.Clean(f.Name)
+	fullPath := filepath.Join(targetDir, name)
 
-		err = os.MkdirAll(filepath.Dir(fullPath), 0755)
-		if err != nil {
-			return err
-		}
+	rel, err := filepath.Rel(targetDir, fullPath)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("zip entry escapes target dir: %s", f.Name)
+	}
 
-		rc, err := f.Open()
-		if err != nil {
-			return err
-		}
+	if f.FileInfo().IsDir() {
+		return os.MkdirAll(fullPath, 0755)
+	}
 
-		perm := f.Mode().Perm()
-		if perm == 0 {
-			perm = 0644
-		}
-		w, err := os.OpenFile(fullPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
-		if err != nil {
-			rc.Close()
-			return err
-		}
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		return err
+	}
 
-		_, copyErr := io.Copy(w, rc)
-		closeErr := w.Close()
-		rcErr := rc.Close()
-		if copyErr != nil {
-			return copyErr
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	perm := f.Mode().Perm()
+	if perm == 0 {
+		perm = 0644
+	}
+	w, err := os.OpenFile(fullPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cerr := w.Close()
+		if err == nil {
+			err = cerr
 		}
-		if closeErr != nil {
-			return closeErr
-		}
-		if rcErr != nil {
-			return rcErr
-		}
+	}()
+
+	if _, err = io.Copy(w, rc); err != nil {
+		return err
 	}
 	return nil
 }

--- a/script/download-go/main.go
+++ b/script/download-go/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"archive/zip"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -19,8 +21,10 @@ import (
 
 const downloadListURL = "https://go.dev/dl"
 
-// download link example: https://go.dev/dl/go1.22.1.linux-386.tar.gz
-const baseNameTemplate = "go%s.%s-%s.tar.gz"
+// download link examples:
+//   https://go.dev/dl/go1.22.1.linux-386.tar.gz
+//   https://go.dev/dl/go1.22.1.windows-amd64.zip
+const baseNameTemplate = "go%s.%s-%s%s"
 const downloadLinkPrefix = "https://go.dev/dl/"
 
 const goReleaseDir = "go-release"
@@ -132,7 +136,7 @@ func downloadGo(ctx context.Context, version string, downloadDir string) error {
 		return err
 	}
 
-	baseName := fmt.Sprintf(baseNameTemplate, nakedVersion, goos, goarch)
+	baseName := fmt.Sprintf(baseNameTemplate, nakedVersion, goos, goarch, getArchiveSuffix(goos))
 	downloadLink := downloadLinkPrefix + baseName
 
 	goDirName := filepath.Join(downloadDir, "go"+nakedVersion)
@@ -164,12 +168,12 @@ func downloadGo(ctx context.Context, version string, downloadDir string) error {
 		return err
 	}
 
-	goTmpDir, err := os.MkdirTemp(".", "go")
+	goTmpDir, err := os.MkdirTemp(downloadDir, "go-extract-")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(goTmpDir)
-	err = cmd_exec.Run("tar", "-C", goTmpDir, "-xzf", downloadFile)
+	err = extractArchive(downloadFile, goTmpDir)
 	if err != nil {
 		return err
 	}
@@ -181,6 +185,82 @@ func downloadGo(ctx context.Context, version string, downloadDir string) error {
 }
 func curlDownload(url string, file string) error {
 	return cmd_exec.Run("curl"+osinfo.EXE_SUFFIX, "-L", "-o", file, url)
+}
+
+func getArchiveSuffix(goos string) string {
+	if goos == "windows" {
+		return ".zip"
+	}
+	return ".tar.gz"
+}
+
+func extractArchive(archiveFile string, targetDir string) error {
+	if strings.HasSuffix(archiveFile, ".zip") {
+		return unzip(archiveFile, targetDir)
+	}
+	return cmd_exec.Run("tar", "-C", targetDir, "-xzf", archiveFile)
+}
+
+func unzip(zipFile string, targetDir string) error {
+	r, err := zip.OpenReader(zipFile)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		name := filepath.Clean(f.Name)
+		fullPath := filepath.Join(targetDir, name)
+		rel, err := filepath.Rel(targetDir, fullPath)
+		if err != nil {
+			return err
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("zip entry escapes target dir: %s", f.Name)
+		}
+
+		if f.FileInfo().IsDir() {
+			err = os.MkdirAll(fullPath, 0755)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		err = os.MkdirAll(filepath.Dir(fullPath), 0755)
+		if err != nil {
+			return err
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+
+		perm := f.Mode().Perm()
+		if perm == 0 {
+			perm = 0644
+		}
+		w, err := os.OpenFile(fullPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+
+		_, copyErr := io.Copy(w, rc)
+		closeErr := w.Close()
+		rcErr := rc.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if rcErr != nil {
+			return rcErr
+		}
+	}
+	return nil
 }
 
 type DownloadInfo struct {

--- a/script/download-go/main_test.go
+++ b/script/download-go/main_test.go
@@ -1,0 +1,394 @@
+package main
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGetArchiveSuffix(t *testing.T) {
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{"windows", ".zip"},
+		{"linux", ".tar.gz"},
+		{"darwin", ".tar.gz"},
+		{"freebsd", ".tar.gz"},
+	}
+
+	for _, tt := range tests {
+		got := getArchiveSuffix(tt.goos)
+		if got != tt.want {
+			t.Errorf("getArchiveSuffix(%q) = %q, want %q", tt.goos, got, tt.want)
+		}
+	}
+}
+
+func TestParseDownloadVersions(t *testing.T) {
+	html := `
+		<html>
+		<body>
+		<div id="go1.22.1"></div>
+		<div id="go1.21.0"></div>
+		<div id="go1.20.3"></div>
+		<div>no version</div>
+		<div id="something-else">skip</div>
+		</body>
+		</html>
+	`
+
+	versions := parseDownloadVersions(html)
+
+	expected := []string{"1.22.1", "1.21.0", "1.20.3"}
+	if len(versions) != len(expected) {
+		t.Fatalf("got %d versions, want %d: %v", len(versions), len(expected), versions)
+	}
+	for i, v := range versions {
+		if v != expected[i] {
+			t.Errorf("version[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestParseDownloadVersionsEmpty(t *testing.T) {
+	versions := parseDownloadVersions("<html><body></body></html>")
+	if len(versions) != 0 {
+		t.Errorf("expected empty, got %v", versions)
+	}
+}
+
+func TestExtractArchiveTarGz(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tar extraction test requires tar command")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Verify that a non-.zip file dispatches to tar command
+	err := extractArchive("/nonexistent/test.tar.gz", tmpDir)
+	if err == nil {
+		t.Fatal("expected error for nonexistent tar.gz")
+	}
+}
+
+func TestExtractArchiveZip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a valid zip for testing
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	if err := createTestZip(zipPath, map[string]string{
+		"go/README": "hello",
+	}); err != nil {
+		t.Fatalf("failed to create test zip: %v", err)
+	}
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	err := extractArchive(zipPath, extractDir)
+	if err != nil {
+		t.Fatalf("extractArchive failed: %v", err)
+	}
+
+	// Verify file was extracted
+	content, err := os.ReadFile(filepath.Join(extractDir, "go", "README"))
+	if err != nil {
+		t.Fatalf("failed to read extracted file: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Errorf("expected 'hello', got %q", string(content))
+	}
+}
+
+func TestUnzip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	if err := createTestZip(zipPath, map[string]string{
+		"go/bin/go":    "mock-binary",
+		"go/src/main":  "package main",
+		"go/README.md": "# Go Docs",
+	}); err != nil {
+		t.Fatalf("failed to create test zip: %v", err)
+	}
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	if err := unzip(zipPath, extractDir); err != nil {
+		t.Fatalf("unzip failed: %v", err)
+	}
+
+	// Verify all files extracted
+	testCases := []struct {
+		path    string
+		content string
+	}{
+		{"go/bin/go", "mock-binary"},
+		{"go/src/main", "package main"},
+		{"go/README.md", "# Go Docs"},
+	}
+
+	for _, tc := range testCases {
+		content, err := os.ReadFile(filepath.Join(extractDir, tc.path))
+		if err != nil {
+			t.Errorf("failed to read %s: %v", tc.path, err)
+			continue
+		}
+		if string(content) != tc.content {
+			t.Errorf("%s content = %q, want %q", tc.path, string(content), tc.content)
+		}
+	}
+}
+
+func TestUnzipDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	if err := createTestZipWithDirs(zipPath, []string{
+		"go/",
+		"go/bin/",
+		"go/src/",
+	}, map[string]string{
+		"go/bin/go": "binary",
+	}); err != nil {
+		t.Fatalf("failed to create test zip: %v", err)
+	}
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	if err := unzip(zipPath, extractDir); err != nil {
+		t.Fatalf("unzip failed: %v", err)
+	}
+
+	// Check directories exist
+	for _, dir := range []string{"go", "go/bin", "go/src"} {
+		fi, err := os.Stat(filepath.Join(extractDir, dir))
+		if err != nil {
+			t.Errorf("directory %s not found: %v", dir, err)
+			continue
+		}
+		if !fi.IsDir() {
+			t.Errorf("%s is not a directory", dir)
+		}
+	}
+}
+
+func TestUnzipPathTraversal_RelativeParent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	if err := createTestZipWithRawNames(zipPath, map[string]string{
+		"../evil": "malicious content",
+	}); err != nil {
+		t.Fatalf("failed to create test zip: %v", err)
+	}
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	err := unzip(zipPath, extractDir)
+	if err == nil {
+		t.Fatal("expected error for path traversal, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes target dir") {
+		t.Errorf("expected 'escapes target dir' error, got: %v", err)
+	}
+}
+
+func TestUnzipPathTraversal_NestedParent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	if err := createTestZipWithRawNames(zipPath, map[string]string{
+		"foo/../../../evil": "malicious content",
+	}); err != nil {
+		t.Fatalf("failed to create test zip: %v", err)
+	}
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	err := unzip(zipPath, extractDir)
+	if err == nil {
+		t.Fatal("expected error for path traversal, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes target dir") {
+		t.Errorf("expected 'escapes target dir' error, got: %v", err)
+	}
+}
+
+func TestUnzipPathTraversal_SingleDot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	if err := createTestZipWithRawNames(zipPath, map[string]string{
+		"go/./bin/go": "binary",
+	}); err != nil {
+		t.Fatalf("failed to create test zip: %v", err)
+	}
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	if err := unzip(zipPath, extractDir); err != nil {
+		t.Fatalf("unzip failed: %v", err)
+	}
+
+	// filepath.Clean should normalize . away
+	content, err := os.ReadFile(filepath.Join(extractDir, "go", "bin", "go"))
+	if err != nil {
+		t.Fatalf("failed to read extracted file: %v", err)
+	}
+	if string(content) != "binary" {
+		t.Errorf("expected 'binary', got %q", string(content))
+	}
+}
+
+func TestUnzipFilePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	if err := createTestZipWithPerms(zipPath, map[string]zipEntry{
+		"go/bin/go": {content: "binary", mode: 0755},
+		"go/readme": {content: "text", mode: 0644},
+	}); err != nil {
+		t.Fatalf("failed to create test zip: %v", err)
+	}
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	if err := unzip(zipPath, extractDir); err != nil {
+		t.Fatalf("unzip failed: %v", err)
+	}
+
+	fi, err := os.Stat(filepath.Join(extractDir, "go", "bin", "go"))
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+	if fi.Mode().Perm() != 0755 {
+		t.Errorf("expected 0755, got %04o", fi.Mode().Perm())
+	}
+
+	fi2, err := os.Stat(filepath.Join(extractDir, "go", "readme"))
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+	if fi2.Mode().Perm() != 0644 {
+		t.Errorf("expected 0644, got %04o", fi2.Mode().Perm())
+	}
+}
+
+func TestUnzipEmptyZip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	zw := zip.NewWriter(f)
+	if err := zw.Close(); err != nil {
+		f.Close()
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	f.Close()
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	if err := unzip(zipPath, extractDir); err != nil {
+		t.Fatalf("unzip empty zip should succeed: %v", err)
+	}
+}
+
+// Helper functions to create test zip files
+
+func createTestZip(zipPath string, files map[string]string) error {
+	entries := make(map[string]zipEntry)
+	for name, content := range files {
+		entries[name] = zipEntry{content: content}
+	}
+	return createTestZipWithPerms(zipPath, entries)
+}
+
+type zipEntry struct {
+	content string
+	mode    os.FileMode
+}
+
+func createTestZipWithPerms(zipPath string, files map[string]zipEntry) error {
+	f, err := os.Create(zipPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	for name, entry := range files {
+		hdr := &zip.FileHeader{
+			Name:   name,
+			Method: zip.Deflate,
+		}
+		if entry.mode != 0 {
+			hdr.SetMode(entry.mode)
+		}
+		w, err := zw.CreateHeader(hdr)
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte(entry.content)); err != nil {
+			return err
+		}
+	}
+	return zw.Close()
+}
+
+func createTestZipWithDirs(zipPath string, dirs []string, files map[string]string) error {
+	f, err := os.Create(zipPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+
+	for _, dir := range dirs {
+		_, err := zw.CreateHeader(&zip.FileHeader{
+			Name: dir,
+			Method: zip.Store,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	for name, content := range files {
+		w, err := zw.CreateHeader(&zip.FileHeader{
+			Name:   name,
+			Method: zip.Deflate,
+		})
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			return err
+		}
+	}
+
+	return zw.Close()
+}
+
+func createTestZipWithRawNames(zipPath string, files map[string]string) error {
+	f, err := os.Create(zipPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	for name, content := range files {
+		w, err := zw.CreateHeader(&zip.FileHeader{
+			Name:   name,
+			Method: zip.Deflate,
+		})
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			return err
+		}
+	}
+	return zw.Close()
+}


### PR DESCRIPTION
## Summary

Fix `script/download-go` on Windows by downloading the correct Go archive format and extracting it properly.

## Problem

The downloader previously assumed all Go distributions were `.tar.gz` archives and always extracted them with `tar -xzf`. This breaks on Windows, where official Go releases are distributed as `.zip` files.

As a result, Windows users cannot bootstrap a supported Go toolchain into `go-release/`, which blocks the subsequent `xgo` setup flow.

## Changes

- choose archive suffix by platform:
  - Windows: `.zip`
  - others: `.tar.gz`
- add a shared archive extraction path
- implement zip extraction with Go's `archive/zip`
- restore temp directory cleanup
- add path validation during zip extraction

## Validation

Verified on Windows with:

```powershell
go run ./script/download-go go1.24.2
go test ./script/download-go
xgo setup
xgo test -run TestHelloWorld -v ./test