### PR TITLE
Support go1.26 (with omniaura attribution)

### DIFF
--- a/cmd/xgo/dual_patch_policy_test.go
+++ b/cmd/xgo/dual_patch_policy_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/xhd2015/xgo/support/goinfo"
+)
+
+// TestDualPatchPolicy documents the go1.24–go1.27 patch routing policy:
+//   - go1.24–go1.25: legacy instrument_go or file-based (explicit choice)
+//   - go1.26: dual-path — file-based by default, legacy via --use-file-patches=false
+//   - go1.27+: file-based only
+func TestDualPatchPolicy(t *testing.T) {
+	versions := []struct {
+		name string
+		ver  *goinfo.GoVersion
+	}{
+		{"go1.24", &goinfo.GoVersion{Major: 1, Minor: 24}},
+		{"go1.25", &goinfo.GoVersion{Major: 1, Minor: 25}},
+		{"go1.26", &goinfo.GoVersion{Major: 1, Minor: 26}},
+		{"go1.27", &goinfo.GoVersion{Major: 1, Minor: 27}},
+	}
+
+	type want struct {
+		value bool
+		err   bool
+	}
+
+	// nil explicit → version-based default
+	defaults := map[string]want{
+		"go1.24": {value: false},
+		"go1.25": {value: true},
+		"go1.26": {value: true},
+		"go1.27": {value: true},
+	}
+
+	// explicit true → file-based where supported (go1.24+)
+	explicitTrue := map[string]want{
+		"go1.24": {value: true},
+		"go1.25": {value: true},
+		"go1.26": {value: true},
+		"go1.27": {value: true},
+	}
+
+	// explicit false → legacy where allowed; go1.27+ rejects
+	explicitFalse := map[string]want{
+		"go1.24": {value: false},
+		"go1.25": {value: false},
+		"go1.26": {value: false},
+		"go1.27": {err: true},
+	}
+
+	for _, mode := range []struct {
+		name    string
+		explicit func(bool) *bool
+		wants    map[string]want
+	}{
+		{"default", func(b bool) *bool { return nil }, defaults},
+		{"explicit true", ptrBool, explicitTrue},
+		{"explicit false", func(b bool) *bool { v := false; return &v }, explicitFalse},
+	} {
+		for _, v := range versions {
+			t.Run(mode.name+"/"+v.name, func(t *testing.T) {
+				var explicit *bool
+				if mode.explicit != nil {
+					explicit = mode.explicit(true)
+				}
+				want := mode.wants[v.name]
+				got, _, err := resolveUseFilePatches(explicit, v.ver)
+				if want.err {
+					if err == nil {
+						t.Fatal("expected error, got nil")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got != want.value {
+					t.Fatalf("expected useFilePatches=%v, got %v", want.value, got)
+				}
+			})
+		}
+	}
+}

--- a/cmd/xgo/option.go
+++ b/cmd/xgo/option.go
@@ -762,9 +762,9 @@ func resolveUseFilePatches(explicit *bool, goVersion *goinfo.GoVersion) (value b
 		}
 		return true, "", nil
 	}
-	// explicitly false
-	if goVersion != nil && goVersion.Major == 1 && goVersion.Minor > 25 {
-		return false, "", fmt.Errorf("--use-file-patches=false is not supported for go%d.%d; after go1.25, file-based patches are always used", goVersion.Major, goVersion.Minor)
+	// explicitly false — go1.26 is the last version that supports legacy instrument_go
+	if goVersion != nil && goVersion.Major == 1 && goVersion.Minor > 26 {
+		return false, "", fmt.Errorf("--use-file-patches=false is not supported for go%d.%d; from go1.27 onward, file-based patches are always used", goVersion.Major, goVersion.Minor)
 	}
 	return false, "", nil
 }

--- a/cmd/xgo/option_test.go
+++ b/cmd/xgo/option_test.go
@@ -85,12 +85,12 @@ func TestResolveUseFilePatches(t *testing.T) {
 		{name: "go1.23 explicit true", explicit: pbTrue, goVersion: go123, wantErr: true},
 		{name: "nil version explicit true", explicit: pbTrue, wantErr: true},
 
-		// explicit false — only go1.24/go1.25 allow switching
+		// explicit false — go1.24–go1.26 allow switching to legacy instrument_go
 		{name: "go1.25 explicit false", explicit: pbFalse, goVersion: go125, want: false},
 		{name: "go1.24 explicit false", explicit: pbFalse, goVersion: go124, want: false},
+		{name: "go1.26 explicit false", explicit: pbFalse, goVersion: go126, want: false},
 		{name: "go1.23 explicit false", explicit: pbFalse, goVersion: go123, want: false},
 		{name: "go1.17 explicit false", explicit: pbFalse, goVersion: go217, want: false},
-		{name: "go1.26 explicit false", explicit: pbFalse, goVersion: go126, wantErr: true},
 		{name: "go1.27 explicit false", explicit: pbFalse, goVersion: go127, wantErr: true},
 		{name: "nil version explicit false", explicit: pbFalse, want: false},
 	}

--- a/cmd/xgo/trace.go
+++ b/cmd/xgo/trace.go
@@ -392,13 +392,19 @@ func loadDependency(goroot string, goBinary string, goVersion *goinfo.GoVersion,
 	// which Go 1.25 rejects. See patches/go1.25/issues/RUNTIME_LIB_SELF_REQUIRE.md
 	if mainModule != constants.RUNTIME_MODULE {
 		logDebug("require %s v%s, replaced: %s", constants.RUNTIME_MODULE, VERSION, tmpRuntime)
-		err = cmd.Env([]string{
-			"GOROOT=" + goroot,
-		}).Run(goBinary, "mod", "edit",
+		modEditArgs := []string{"mod", "edit",
 			fmt.Sprintf("-require=%s@v%s", constants.RUNTIME_MODULE, VERSION),
 			fmt.Sprintf("-replace=%s=%s", constants.RUNTIME_MODULE, tmpRuntime),
-			tmpGoMod,
-		)
+		}
+		// In Go 1.26+, 'go mod tidy' is required when using old go directives (e.g. go 1.14)
+		// with require/replace. Bump the go directive to at least 1.18 to avoid this.
+		if goVersion.Minor >= 26 {
+			modEditArgs = append(modEditArgs, fmt.Sprintf("-go=%d.%d", goVersion.Major, goVersion.Minor))
+		}
+		modEditArgs = append(modEditArgs, tmpGoMod)
+		err = cmd.Env([]string{
+			"GOROOT=" + goroot,
+		}).Run(goBinary, modEditArgs...)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -7,8 +7,8 @@ import "fmt"
 // VERSION is manually updated when needed a new tag
 // if you did not install git hooks, you can manually update them
 const VERSION = "1.2.0"
-const REVISION = "d6c802585eb73262128a125e7934fbeb2b197a6d+1"
-const NUMBER = 630
+const REVISION = "520195c1cb5c907c9fce8a64bb9aca7839b1614b+1"
+const NUMBER = 631
 
 // Rationale: xgo consists of these modules:
 //

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -7,8 +7,8 @@ import "fmt"
 // VERSION is manually updated when needed a new tag
 // if you did not install git hooks, you can manually update them
 const VERSION = "1.2.0"
-const REVISION = "520195c1cb5c907c9fce8a64bb9aca7839b1614b+1"
-const NUMBER = 631
+const REVISION = "4367b7519d31763382e24ee003e555a0ba110ace+1"
+const NUMBER = 632
 
 // Rationale: xgo consists of these modules:
 //

--- a/instrument/instrument_go/exec.go
+++ b/instrument/instrument_go/exec.go
@@ -13,9 +13,9 @@ var xgoWorkSumFilePath = internalWorkPath.Append("xgo_work_sum.go") // src/cmd/g
 
 // instrumentExec instrument the internal exec.go to fix coverage with -overlay
 func instrumentExec(goroot string, goVersion *goinfo.GoVersion) error {
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
 		// src/cmd/go/internal/work/exec.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", execFilePath.JoinPrefix(""), goVersion.Major, goVersion.Minor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", execFilePath.JoinPrefix(""), goVersion.Major, goVersion.Minor)
 	}
 	execFile := execFilePath.JoinPrefix(goroot)
 
@@ -84,8 +84,9 @@ func instrumentExec(goroot string, goVersion *goinfo.GoVersion) error {
 				strings.TrimSuffix(getActualFile, ";")+";"+"infiles = append(infiles, __xgo_overlay_source_file)",
 			)
 		}
-		if goVersion.Minor >= 25 {
+		if goVersion.Minor == 25 {
 			// In go1.25, CoverageRedesign is always on, so infiles append is unconditional
+			// but still inside func (b *Builder) build(
 			content = patch.UpdateContent(content,
 				"/*<begin modify_infiles>*/",
 				"/*<end modify_infiles>*/",
@@ -95,6 +96,21 @@ func instrumentExec(goroot string, goVersion *goinfo.GoVersion) error {
 					"infiles = append(infiles, sourceFile)",
 				},
 				2,
+				patch.UpdatePosition_Replace,
+				strings.TrimSuffix(getActualFile, ";")+";"+"infiles = append(infiles, __xgo_overlay_source_file)",
+			)
+		}
+		if goVersion.Minor >= 26 {
+			// In go1.26, coverage logic was moved from build() to runCover().
+			// The infiles append is in func (b *Builder) runCover(, unconditional.
+			content = patch.UpdateContent(content,
+				"/*<begin modify_infiles>*/",
+				"/*<end modify_infiles>*/",
+				[]string{
+					"func (b *Builder) runCover(",
+					"infiles = append(infiles, sourceFile)",
+				},
+				1,
 				patch.UpdatePosition_Replace,
 				strings.TrimSuffix(getActualFile, ";")+";"+"infiles = append(infiles, __xgo_overlay_source_file)",
 			)

--- a/instrument/instrument_go/exec_go126_test.go
+++ b/instrument/instrument_go/exec_go126_test.go
@@ -1,0 +1,52 @@
+package instrument_go
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xhd2015/xgo/support/goinfo"
+)
+
+const execStubGo126 = `package work
+
+func (b *Builder) runCover() {
+	infiles = append(infiles, sourceFile)
+}
+
+func (b *Builder) buildActionID() {
+	fmt.Fprintf(h, "compile\n")
+}
+`
+
+func TestInstrumentExecGo126PatchesRunCoverInfiles(t *testing.T) {
+	goroot := t.TempDir()
+	execDir := filepath.Join(goroot, "src", "cmd", "go", "internal", "work")
+	if err := os.MkdirAll(execDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	execPath := filepath.Join(execDir, "exec.go")
+	if err := os.WriteFile(execPath, []byte(execStubGo126), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := instrumentExec(goroot, &goinfo.GoVersion{Major: 1, Minor: 26}); err != nil {
+		t.Fatalf("instrumentExec go1.26: %v", err)
+	}
+
+	out, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(out)
+	if !strings.Contains(content, "func (b *Builder) runCover(") {
+		t.Fatalf("runCover anchor missing after patch:\n%s", content)
+	}
+	if !strings.Contains(content, "/*<begin modify_infiles>*/") {
+		t.Fatalf("modify_infiles patch marker missing:\n%s", content)
+	}
+	if !strings.Contains(content, "infiles = append(infiles, __xgo_overlay_source_file)") {
+		t.Fatalf("expected runCover infiles overlay patch, got:\n%s", content)
+	}
+}

--- a/instrument/instrument_go/go_cmd.go
+++ b/instrument/instrument_go/go_cmd.go
@@ -89,9 +89,9 @@ func copyWorkSum(goroot string) error {
 }
 
 func instrumentGoMain(goroot string, goVersion *goinfo.GoVersion) error {
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
 		// src/cmd/go/main.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", execFilePath.JoinPrefix(""), goVersion.Major, goVersion.Minor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", execFilePath.JoinPrefix(""), goVersion.Major, goVersion.Minor)
 	}
 	mainFile := mainFilePath.JoinPrefix(goroot)
 	return patch.EditFile(mainFile, func(content string) (string, error) {

--- a/instrument/instrument_go/go_tool_cover.go
+++ b/instrument/instrument_go/go_tool_cover.go
@@ -45,9 +45,9 @@ func copyXgoCover(goroot string) error {
 }
 
 func instrumentCmdCover(goroot string, goVersion *goinfo.GoVersion) error {
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
 		// src/cmd/cover/cover.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", coverFilePath.JoinPrefix(""), goVersion.Major, goVersion.Minor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", coverFilePath.JoinPrefix(""), goVersion.Major, goVersion.Minor)
 	}
 	coverFile := coverFilePath.JoinPrefix(goroot)
 

--- a/instrument/instrument_go/instrument_unifiedtest/go126_patch_test.go
+++ b/instrument/instrument_go/instrument_unifiedtest/go126_patch_test.go
@@ -1,0 +1,121 @@
+package instrument_unifiedtest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xhd2015/xgo/support/goinfo"
+)
+
+const testGoStubGo126 = `package test
+
+import "context"
+
+func runTest(ctx context.Context,
+) {
+	pkgs = load.PackagesAndErrors(moduleLoaderState, ctx,
+		load.PackageOpts{},
+		nil,
+	)
+}
+
+func (r *runTestActor) Act() {
+	cmd.Dir = a.Package.Dir
+}
+`
+
+const loadTestStubGo126 = `package load
+
+import "context"
+
+func TestPackagesAndErrors(loaderstate *modload.State, ctx context.Context,
+	t *testing.T,
+) {
+	_, err := formatTestmain(t)
+}
+
+func loadTestFuncs(ptest *Package) {
+}
+`
+
+const test2jsonStubGo126 = `package test2json
+
+func (c *Converter) writeEvent(e *event) {
+	js, err := json.Marshal(e)
+}
+`
+
+func writeGo126Goroot(t *testing.T) string {
+	t.Helper()
+	goroot := t.TempDir()
+	dirs := []struct {
+		dir  string
+		file string
+		body string
+	}{
+		{"src/cmd/go/internal/test", "test.go", testGoStubGo126},
+		{"src/cmd/go/internal/load", "test.go", loadTestStubGo126},
+		{"src/cmd/internal/test2json", "test2json.go", test2jsonStubGo126},
+	}
+	for _, d := range dirs {
+		p := filepath.Join(goroot, d.dir)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(p, d.file), []byte(d.body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return goroot
+}
+
+func TestUnifyGo126PatchesModuleLoaderState(t *testing.T) {
+	goroot := writeGo126Goroot(t)
+	goVer := &goinfo.GoVersion{Major: 1, Minor: 26}
+
+	if err := Unify(goroot, goVer); err != nil {
+		t.Fatalf("Unify go1.26: %v", err)
+	}
+
+	testPath := filepath.Join(goroot, "src", "cmd", "go", "internal", "test", "test.go")
+	testContent, err := os.ReadFile(testPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(testContent), "xgoModuleLoaderState = moduleLoaderState") {
+		t.Fatalf("test.go missing moduleLoaderState assignment:\n%s", testContent)
+	}
+	if !strings.Contains(string(testContent), "pkgs = xgoUnifyTestPackages(ctx, pkgs)") {
+		t.Fatalf("test.go missing unify call:\n%s", testContent)
+	}
+
+	unifiedPath := filepath.Join(goroot, "src", "cmd", "go", "internal", "test", "xgo_testunified.go")
+	unifiedContent, err := os.ReadFile(unifiedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := string(unifiedContent)
+	if !strings.Contains(u, "cmd/go/internal/modload") {
+		t.Fatalf("xgo_testunified.go missing modload import:\n%s", u)
+	}
+	if !strings.Contains(u, "xgoModuleLoaderState *modload.State") {
+		t.Fatalf("xgo_testunified.go missing loader state var:\n%s", u)
+	}
+	if !strings.Contains(u, "load.PackagesAndErrors(xgoModuleLoaderState, ctx,") {
+		t.Fatalf("xgo_testunified.go missing loader state arg:\n%s", u)
+	}
+
+	loadPath := filepath.Join(goroot, "src", "cmd", "go", "internal", "load", "test.go")
+	loadContent, err := os.ReadFile(loadPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(loadContent), "func TestPackagesAndErrors(loaderstate *modload.State, ctx context.Context,") {
+		t.Fatalf("load/test.go anchor not preserved:\n%s", loadContent)
+	}
+	if !strings.Contains(string(loadContent), "XgoAfterGenerateTestMain") {
+		t.Fatalf("load/test.go missing testmain hook:\n%s", loadContent)
+	}
+}

--- a/instrument/instrument_go/instrument_unifiedtest/load.go
+++ b/instrument/instrument_go/instrument_unifiedtest/load.go
@@ -14,17 +14,22 @@ var loadTestFile = patch.FilePath{"src", "cmd", "go", "internal", "load", "test.
 
 func instrumentLoadTest(goroot string, goVersion *goinfo.GoVersion) error {
 	fileName := loadTestFile.JoinPrefix()
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", fileName, goVersion.Major, goVersion.Minor)
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", fileName, goVersion.Major, goVersion.Minor)
 	}
 	file := filepath.Join(goroot, fileName)
 
 	return patch.EditFile(file, func(content string) (string, error) {
+		// In go1.26, TestPackagesAndErrors signature changed to include loaderstate param
+		testPkgsAnchor := "func TestPackagesAndErrors(ctx context.Context,"
+		if goVersion.Minor >= 26 {
+			testPkgsAnchor = "func TestPackagesAndErrors(loaderstate *modload.State, ctx context.Context,"
+		}
 		content = patch.UpdateContent(content,
 			"/*<begin declare_XgoAfterGenerateTestMain>*/",
 			"/*<end declare_XgoAfterGenerateTestMain>*/",
 			[]string{
-				"func TestPackagesAndErrors(ctx context.Context,",
+				testPkgsAnchor,
 			},
 			0,
 			patch.UpdatePosition_Before,
@@ -35,7 +40,7 @@ func instrumentLoadTest(goroot string, goVersion *goinfo.GoVersion) error {
 			"/*<begin call_XgoAfterGenerateTestMain>*/",
 			"/*<end call_XgoAfterGenerateTestMain>*/",
 			[]string{
-				"func TestPackagesAndErrors(ctx context.Context,",
+				testPkgsAnchor,
 				", err := formatTestmain(t)",
 			},
 			1,

--- a/instrument/instrument_go/instrument_unifiedtest/test2json.go
+++ b/instrument/instrument_go/instrument_unifiedtest/test2json.go
@@ -14,8 +14,8 @@ var test2jsonFile = patch.FilePath{"src", "cmd", "internal", "test2json", "test2
 
 func instrumentTest2json(goroot string, goVersion *goinfo.GoVersion) error {
 	fileName := test2jsonFile.JoinPrefix()
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", fileName, goVersion.Major, goVersion.Minor)
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", fileName, goVersion.Major, goVersion.Minor)
 	}
 	file := filepath.Join(goroot, fileName)
 

--- a/instrument/instrument_go/instrument_unifiedtest/unified.go
+++ b/instrument/instrument_go/instrument_unifiedtest/unified.go
@@ -25,11 +25,11 @@ var testFile = patch.FilePath{"src", "cmd", "go", "internal", "test", "test.go"}
 
 func Unify(goroot string, goVersion *goinfo.GoVersion) error {
 	// src/cmd/go/internal/test
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
-		return fmt.Errorf("unified test unsupported version: go%d.%d, available: go1.17~go1.25", goVersion.Major, goVersion.Minor)
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
+		return fmt.Errorf("unified test unsupported version: go%d.%d, available: go1.17~go1.26", goVersion.Major, goVersion.Minor)
 	}
 
-	err := copyFiles(internalTestPath.JoinPrefix(goroot))
+	err := copyFiles(internalTestPath.JoinPrefix(goroot), goVersion)
 	if err != nil {
 		return err
 	}
@@ -51,12 +51,12 @@ func Unify(goroot string, goVersion *goinfo.GoVersion) error {
 	return nil
 }
 
-func copyFiles(targetDir string) error {
+func copyFiles(targetDir string, goVersion *goinfo.GoVersion) error {
 	err := copyXgoTestinfo(targetDir)
 	if err != nil {
 		return err
 	}
-	err = copyXgoTestunified(targetDir)
+	err = copyXgoTestunified(targetDir, goVersion)
 	if err != nil {
 		return err
 	}
@@ -75,10 +75,28 @@ func copyXgoTestinfo(targetDir string) error {
 	return nil
 }
 
-func copyXgoTestunified(targetDir string) error {
+func copyXgoTestunified(targetDir string, goVersion *goinfo.GoVersion) error {
 	xgoTestunified, err := patch.RemoveBuildIgnore(xgoTestunifiedTemplate)
 	if err != nil {
 		return err
+	}
+	// In go1.26, load.PackagesAndErrors gained a *modload.State param.
+	// We add a package-level var to hold the state, set from the patched runTest code.
+	if goVersion.Minor >= 26 {
+		xgoTestunified = strings.Replace(xgoTestunified,
+			`"cmd/go/internal/load"`,
+			"\"cmd/go/internal/load\"\n\t\"cmd/go/internal/modload\"",
+			1,
+		)
+		xgoTestunified = strings.Replace(xgoTestunified,
+			"var _ = builderTest",
+			"var _ = builderTest\nvar xgoModuleLoaderState *modload.State",
+			1,
+		)
+		xgoTestunified = strings.ReplaceAll(xgoTestunified,
+			"load.PackagesAndErrors(ctx, load.PackageOpts{}, missing)",
+			"load.PackagesAndErrors(xgoModuleLoaderState, ctx, load.PackageOpts{}, missing)",
+		)
 	}
 	err = os.WriteFile(filepath.Join(targetDir, "xgo_testunified.go"), []byte(xgoTestunified), 0644)
 	if err != nil {
@@ -89,8 +107,8 @@ func copyXgoTestunified(targetDir string) error {
 
 func instrumentTestUnifyAndCleanup(goroot string, goVersion *goinfo.GoVersion) error {
 	fileName := testFile.JoinPrefix()
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", fileName, goVersion.Major, goVersion.Minor)
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", fileName, goVersion.Major, goVersion.Minor)
 	}
 
 	return patch.EditFile(filepath.Join(goroot, fileName), func(content string) (string, error) {
@@ -105,17 +123,27 @@ func instrumentTestUnifyAndCleanup(goroot string, goVersion *goinfo.GoVersion) e
 			patch.UpdatePosition_After,
 			"defer xgoCleanup();",
 		)
+		// In go1.26, load.PackagesAndErrors signature changed to include moduleLoaderState
+		pkgsAnchor := "pkgs = load.PackagesAndErrors(ctx,"
+		if goVersion.Minor >= 26 {
+			pkgsAnchor = "pkgs = load.PackagesAndErrors(moduleLoaderState, ctx,"
+		}
+		unifyCall := ";pkgs = xgoUnifyTestPackages(ctx, pkgs)"
+		if goVersion.Minor >= 26 {
+			// Set the module loader state before unifying test packages
+			unifyCall = ";xgoModuleLoaderState = moduleLoaderState;pkgs = xgoUnifyTestPackages(ctx, pkgs)"
+		}
 		content = patch.UpdateContent(content,
 			"/*<begin call_xgoUnifyTestPackages>*/",
 			"/*<end call_xgoUnifyTestPackages>*/",
 			[]string{
 				"func runTest(ctx context.Context,",
-				"pkgs = load.PackagesAndErrors(ctx,",
+				pkgsAnchor,
 				")",
 			},
 			2,
 			patch.UpdatePosition_After,
-			";pkgs = xgoUnifyTestPackages(ctx, pkgs)",
+			unifyCall,
 		)
 
 		// set pkg dir

--- a/instrument/instrument_go/pkg.go
+++ b/instrument/instrument_go/pkg.go
@@ -49,9 +49,9 @@ func instrumentPkgLoad(goroot string, goVersion *goinfo.GoVersion) error {
 		// see https://github.com/xhd2015/xgo/issues/318#issuecomment-2809243930
 		return nil
 	}
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
 		// src/cmd/go/internal/load/pkg.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", srcCmdGoLoadPkgPath.JoinPrefix(""), goVersion.Major, goVersion.Minor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", srcCmdGoLoadPkgPath.JoinPrefix(""), goVersion.Major, goVersion.Minor)
 	}
 	pkgFile := srcCmdGoLoadPkgPath.JoinPrefix(goroot)
 	return patch.EditFile(pkgFile, func(content string) (string, error) {

--- a/instrument/instrument_go/version_bounds_test.go
+++ b/instrument/instrument_go/version_bounds_test.go
@@ -1,0 +1,70 @@
+package instrument_go
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xhd2015/xgo/instrument/instrument_go/instrument_unifiedtest"
+	"github.com/xhd2015/xgo/support/goinfo"
+)
+
+func TestInstrumentExecSupportsGo126(t *testing.T) {
+	goroot := t.TempDir()
+	execDir := filepath.Join(goroot, "src", "cmd", "go", "internal", "work")
+	if err := os.MkdirAll(execDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "exec.go"), []byte("package work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := instrumentExec(goroot, &goinfo.GoVersion{Major: 1, Minor: 26})
+	if err != nil && strings.Contains(err.Error(), "unsupported version") {
+		t.Fatalf("go1.26 must be supported by legacy instrumentExec, got: %v", err)
+	}
+}
+
+func TestInstrumentExecRejectsGo127(t *testing.T) {
+	err := instrumentExec(t.TempDir(), &goinfo.GoVersion{Major: 1, Minor: 27})
+	if err == nil || !strings.Contains(err.Error(), "unsupported version") {
+		t.Fatalf("go1.27 must be rejected (legacy capped at go1.26), got: %v", err)
+	}
+}
+
+func TestUnifySupportsGo126(t *testing.T) {
+	goroot := t.TempDir()
+	testDir := filepath.Join(goroot, "src", "cmd", "go", "internal", "test")
+	if err := os.MkdirAll(testDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testDir, "test.go"), []byte("package test\nfunc runTest() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loadDir := filepath.Join(goroot, "src", "cmd", "go", "internal", "load")
+	if err := os.MkdirAll(loadDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(loadDir, "test.go"), []byte("package load\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jsonDir := filepath.Join(goroot, "src", "cmd", "internal", "test2json")
+	if err := os.MkdirAll(jsonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jsonDir, "test2json.go"), []byte("package test2json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := instrument_unifiedtest.Unify(goroot, &goinfo.GoVersion{Major: 1, Minor: 26})
+	if err != nil && strings.Contains(err.Error(), "unsupported version") {
+		t.Fatalf("go1.26 must be supported by legacy unified test instrument, got: %v", err)
+	}
+}
+
+func TestGO_VERSION_26Constant(t *testing.T) {
+	if goinfo.GO_VERSION_26 != 26 {
+		t.Fatalf("GO_VERSION_26 = %d, want 26", goinfo.GO_VERSION_26)
+	}
+}

--- a/instrument/instrument_go/version_bounds_test.go
+++ b/instrument/instrument_go/version_bounds_test.go
@@ -1,65 +1,16 @@
 package instrument_go
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/xhd2015/xgo/instrument/instrument_go/instrument_unifiedtest"
 	"github.com/xhd2015/xgo/support/goinfo"
 )
-
-func TestInstrumentExecSupportsGo126(t *testing.T) {
-	goroot := t.TempDir()
-	execDir := filepath.Join(goroot, "src", "cmd", "go", "internal", "work")
-	if err := os.MkdirAll(execDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(execDir, "exec.go"), []byte("package work\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	err := instrumentExec(goroot, &goinfo.GoVersion{Major: 1, Minor: 26})
-	if err != nil && strings.Contains(err.Error(), "unsupported version") {
-		t.Fatalf("go1.26 must be supported by legacy instrumentExec, got: %v", err)
-	}
-}
 
 func TestInstrumentExecRejectsGo127(t *testing.T) {
 	err := instrumentExec(t.TempDir(), &goinfo.GoVersion{Major: 1, Minor: 27})
 	if err == nil || !strings.Contains(err.Error(), "unsupported version") {
 		t.Fatalf("go1.27 must be rejected (legacy capped at go1.26), got: %v", err)
-	}
-}
-
-func TestUnifySupportsGo126(t *testing.T) {
-	goroot := t.TempDir()
-	testDir := filepath.Join(goroot, "src", "cmd", "go", "internal", "test")
-	if err := os.MkdirAll(testDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(testDir, "test.go"), []byte("package test\nfunc runTest() {}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	loadDir := filepath.Join(goroot, "src", "cmd", "go", "internal", "load")
-	if err := os.MkdirAll(loadDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(loadDir, "test.go"), []byte("package load\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	jsonDir := filepath.Join(goroot, "src", "cmd", "internal", "test2json")
-	if err := os.MkdirAll(jsonDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(jsonDir, "test2json.go"), []byte("package test2json\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	err := instrument_unifiedtest.Unify(goroot, &goinfo.GoVersion{Major: 1, Minor: 26})
-	if err != nil && strings.Contains(err.Error(), "unsupported version") {
-		t.Fatalf("go1.26 must be supported by legacy unified test instrument, got: %v", err)
 	}
 }
 

--- a/instrument/instrument_runtime/instrument_testing/testing.go
+++ b/instrument/instrument_runtime/instrument_testing/testing.go
@@ -15,8 +15,8 @@ var testingFile = patch.FilePath{"src", "testing", "testing.go"}
 
 func Instrument(goroot string, goVersion *goinfo.GoVersion) error {
 	fileName := testingFile.JoinPrefix()
-	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 25) {
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", fileName, goVersion.Major, goVersion.Minor)
+	if goVersion.Major != 1 || (goVersion.Minor < 17 || goVersion.Minor > 26) {
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", fileName, goVersion.Major, goVersion.Minor)
 	}
 
 	return patch.EditFile(filepath.Join(goroot, fileName), func(content string) (string, error) {

--- a/instrument/instrument_runtime/json_encoding.go
+++ b/instrument/instrument_runtime/json_encoding.go
@@ -9,9 +9,9 @@ import (
 const enableCyclicDetect = false
 
 func instrumentJsonEncoding(goroot string, goMajor int, goMinor int) error {
-	if goMajor != 1 || (goMinor < 17 || goMinor > 25) {
+	if goMajor != 1 || (goMinor < 17 || goMinor > 26) {
 		// src/encoding/json/encode.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", jsonEncodingPath.JoinPrefix(""), goMajor, goMinor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", jsonEncodingPath.JoinPrefix(""), goMajor, goMinor)
 	}
 	return patch.EditFile(jsonEncodingPath.JoinPrefix(goroot), func(content string) (string, error) {
 		content = patch.UpdateContent(content,

--- a/instrument/instrument_runtime/runtim2.go
+++ b/instrument/instrument_runtime/runtim2.go
@@ -9,9 +9,9 @@ import (
 var runtime2Path = patch.FilePath{"src", "runtime", "runtime2.go"}
 
 func instrumentRuntime2(goroot string, goMajor int, goMinor int) error {
-	if goMajor != 1 || (goMinor < 17 || goMinor > 25) {
+	if goMajor != 1 || (goMinor < 17 || goMinor > 26) {
 		// src/runtime/runtime2.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", runtime2Path.JoinPrefix(""), goMajor, goMinor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", runtime2Path.JoinPrefix(""), goMajor, goMinor)
 	}
 	runtime2File := runtime2Path.JoinPrefix(goroot)
 

--- a/instrument/instrument_runtime/time.go
+++ b/instrument/instrument_runtime/time.go
@@ -13,9 +13,9 @@ var timeSleepPath = patch.FilePath{"src", "time", "sleep.go"}
 var runtimeTimePath = patch.FilePath{"src", "runtime", "time.go"}
 
 func instrumentTimeNow(goroot string, goMajor int, goMinor int) error {
-	if goMajor != 1 || (goMinor < 17 || goMinor > 25) {
+	if goMajor != 1 || (goMinor < 17 || goMinor > 26) {
 		// src/time/time.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", timePath.JoinPrefix(""), goMajor, goMinor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", timePath.JoinPrefix(""), goMajor, goMinor)
 	}
 	timeFile := timePath.JoinPrefix(goroot)
 	return patch.EditFile(timeFile, func(content string) (string, error) {
@@ -45,9 +45,9 @@ func instrumentTimeNow(goroot string, goMajor int, goMinor int) error {
 }
 
 func instrumentTimeSleep(goroot string, goMajor int, goMinor int) error {
-	if goMajor != 1 || (goMinor < 17 || goMinor > 25) {
+	if goMajor != 1 || (goMinor < 17 || goMinor > 26) {
 		// src/time/sleep.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", timeSleepPath.JoinPrefix(""), goMajor, goMinor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", timeSleepPath.JoinPrefix(""), goMajor, goMinor)
 	}
 	timeFile := timeSleepPath.JoinPrefix(goroot)
 	return patch.EditFile(timeFile, func(content string) (string, error) {
@@ -65,9 +65,9 @@ func instrumentTimeSleep(goroot string, goMajor int, goMinor int) error {
 }
 
 func instrumentRuntimeTimeSleep(goroot string, goMajor int, goMinor int) error {
-	if goMajor != 1 || (goMinor < 17 || goMinor > 25) {
+	if goMajor != 1 || (goMinor < 17 || goMinor > 26) {
 		// src/runtime/time.go
-		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.25", runtimeTimePath.JoinPrefix(""), goMajor, goMinor)
+		return fmt.Errorf("%s unsupported version: go%d.%d, available: go1.17~go1.26", runtimeTimePath.JoinPrefix(""), goMajor, goMinor)
 	}
 	timeFile := runtimeTimePath.JoinPrefix(goroot)
 	return patch.EditFile(timeFile, func(content string) (string, error) {

--- a/patch/legacy/adapter_go1.24_25_26.go
+++ b/patch/legacy/adapter_go1.24_25_26.go
@@ -1,5 +1,5 @@
-//go:build go1.24 && !go1.26
-// +build go1.24,!go1.26
+//go:build go1.24 && !go1.27
+// +build go1.24,!go1.27
 
 package patch
 

--- a/patches/go1.26/CHANGELOG
+++ b/patches/go1.26/CHANGELOG
@@ -1,5 +1,13 @@
 # go1.26 Patch CHANGELOG
 
+## Attribution
+
+Go 1.26 support incorporates work from [@Peyton-Spencer](https://github.com/Peyton-Spencer)'s
+[omniaura/go1.26-support](https://github.com/omniaura/xgo/tree/go1.26-support) branch
+(commit `58f7584`). Legacy `instrument_go` go1.26 handlers coexist with these file-based
+patches. **go1.26 is the last Go version with legacy instrument support; go1.27+ uses
+file-based patches only.**
+
 ## Patch adjustments from go1.25 to go1.26
 
 Seeded from `patches/go1.25`. Compared upstream source in `go-release-git-versioned/go1.25.10` vs `go-release-git-versioned/go1.26.4`.

--- a/script/debug/pr-387/main.go
+++ b/script/debug/pr-387/main.go
@@ -15,10 +15,11 @@ import (
 const prNumber = "389"
 
 var (
-	ciSuccessRe = regexp.MustCompile(`(?m)^\s*✓\s+\S+\s+success\b`)
-	ciSkippedRe = regexp.MustCompile(`(?m)^\s*○\s+\S+\s+skipped\b`)
-	ciFailedRe  = regexp.MustCompile(`(?m)^\s*[✗×]\s+\S+\s+(failure|cancelled|timed_out)\b`)
-	ciPendingRe = regexp.MustCompile(`(?m)^\s*\S+\s+\S+\s+(in_progress|queued|pending)\b`)
+	ansiRe      = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	ciSuccessRe = regexp.MustCompile(`\s+success\s*https?://`)
+	ciSkippedRe = regexp.MustCompile(`\s+skipped\s*https?://`)
+	ciFailedRe  = regexp.MustCompile(`\s+(failure|cancelled|timed_out)\s*https?://`)
+	ciPendingRe = regexp.MustCompile(`\s+(in_progress|queued|pending)\s*https?://`)
 )
 
 func outDir() string {
@@ -79,9 +80,13 @@ type prView struct {
 	} `json:"statusCheckRollup"`
 }
 
+func stripANSI(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
 func parseCIRuns(out string) (failed, pending, succeeded, skipped []string) {
 	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
+		line = strings.TrimSpace(stripANSI(line))
 		if line == "" || strings.HasPrefix(line, "Workflow Runs") {
 			continue
 		}

--- a/script/debug/pr-387/main.go
+++ b/script/debug/pr-387/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-const prNumber = "387"
+const prNumber = "389"
 
 func outDir() string {
 	_, file, _, ok := runtime.Caller(0)
@@ -73,6 +73,13 @@ func main() {
 		strings.TrimSpace(firstLine(fetchOut)),
 		"expected go1.26 in PR summary")
 
+	// CHECK 2b: PR description credits omniaura contribution
+	inspect("PR mentions omniaura/peyton attribution",
+		strings.Contains(strings.ToLower(fetchOut), "omniaura") ||
+			strings.Contains(strings.ToLower(fetchOut), "peyton"),
+		fetchPath,
+		"expected omniaura attribution in PR")
+
 	// CHECK 3: gh pr view returns status checks
 	ghOut, ghErr := run("gh", "pr", "view", prNumber, "--json", "state,title,statusCheckRollup")
 	ghPath := filepath.Join(outDir(), "gh-pr-view.json")
@@ -128,7 +135,7 @@ func main() {
 		summaryPath,
 		strings.Join(failed, ", "))
 
-	fmt.Println("ALL CHECKS PASSED — PR #387 ready")
+	fmt.Println("ALL CHECKS PASSED — PR #" + prNumber + " ready")
 }
 
 func firstLine(s string) string {

--- a/script/debug/pr-387/main.go
+++ b/script/debug/pr-387/main.go
@@ -6,11 +6,20 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const prNumber = "389"
+
+var (
+	ciSuccessRe = regexp.MustCompile(`(?m)^\s*✓\s+\S+\s+success\b`)
+	ciSkippedRe = regexp.MustCompile(`(?m)^\s*○\s+\S+\s+skipped\b`)
+	ciFailedRe  = regexp.MustCompile(`(?m)^\s*[✗×]\s+\S+\s+(failure|cancelled|timed_out)\b`)
+	ciPendingRe = regexp.MustCompile(`(?m)^\s*\S+\s+\S+\s+(in_progress|queued|pending)\b`)
+)
 
 func outDir() string {
 	_, file, _, ok := runtime.Caller(0)
@@ -25,6 +34,21 @@ func run(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func runWithRetry(name string, retries int, delay time.Duration, args ...string) (string, error) {
+	var out string
+	var err error
+	for attempt := 0; attempt <= retries; attempt++ {
+		out, err = run(name, args...)
+		if err == nil || !strings.Contains(out, "rate limit") {
+			return out, err
+		}
+		if attempt < retries {
+			time.Sleep(delay)
+		}
+	}
+	return out, err
 }
 
 func inspect(check string, pass bool, evidence, reason string) {
@@ -55,6 +79,26 @@ type prView struct {
 	} `json:"statusCheckRollup"`
 }
 
+func parseCIRuns(out string) (failed, pending, succeeded, skipped []string) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "Workflow Runs") {
+			continue
+		}
+		switch {
+		case ciFailedRe.MatchString(line):
+			failed = append(failed, line)
+		case ciPendingRe.MatchString(line):
+			pending = append(pending, line)
+		case ciSuccessRe.MatchString(line):
+			succeeded = append(succeeded, line)
+		case ciSkippedRe.MatchString(line):
+			skipped = append(skipped, line)
+		}
+	}
+	return failed, pending, succeeded, skipped
+}
+
 func main() {
 	_ = os.MkdirAll(outDir(), 0o755)
 
@@ -80,60 +124,50 @@ func main() {
 		fetchPath,
 		"expected omniaura attribution in PR")
 
-	// CHECK 3: gh pr view returns status checks
-	ghOut, ghErr := run("gh", "pr", "view", prNumber, "--json", "state,title,statusCheckRollup")
-	ghPath := filepath.Join(outDir(), "gh-pr-view.json")
-	_ = os.WriteFile(ghPath, []byte(ghOut), 0o644)
-	inspect("gh pr view returns status checks",
-		ghErr == nil && strings.Contains(ghOut, "statusCheckRollup"),
-		ghPath,
-		strings.TrimSpace(ghOut))
+	// CHECK 3: github-fetch ci reports workflow status (primary; no gh auth required)
+	ciOut, ciErr := runWithRetry("github-fetch", 3, 30*time.Second, "ci", prNumber)
+	ciPath := filepath.Join(outDir(), "github-fetch-ci.txt")
+	_ = os.WriteFile(ciPath, []byte(ciOut), 0o644)
+	inspect("github-fetch ci returns workflow runs",
+		ciErr == nil && strings.Contains(ciOut, "Workflow Runs"),
+		ciPath,
+		strings.TrimSpace(ciOut))
 
-	var pr prView
-	if err := json.Unmarshal([]byte(ghOut), &pr); err != nil {
-		inspect("parse gh pr view JSON", false, ghPath, err.Error())
-	}
-
-	inspect("PR state is OPEN",
-		strings.EqualFold(pr.State, "OPEN"),
-		pr.State,
-		"PR is not open")
-
-	// CHECK 4: all completed checks are success or skipped (none failed)
-	var failed []string
-	var pending []string
-	for _, c := range pr.Status {
-		switch strings.ToUpper(c.Conclusion) {
-		case "SUCCESS", "SKIPPED", "NEUTRAL":
-			// ok
-		case "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED":
-			failed = append(failed, c.Name+"="+c.Conclusion)
-		case "":
-			if strings.ToUpper(c.Status) == "IN_PROGRESS" || strings.ToUpper(c.Status) == "QUEUED" {
-				pending = append(pending, c.Name+"="+c.Status)
-			}
-		default:
-			if c.Conclusion != "" {
-				failed = append(failed, c.Name+"="+c.Conclusion)
-			}
-		}
-	}
-
+	failed, pending, succeeded, skipped := parseCIRuns(ciOut)
 	summaryPath := filepath.Join(outDir(), "check-summary.txt")
-	summary := fmt.Sprintf("failed: %v\npending: %v\n", failed, pending)
+	summary := fmt.Sprintf("succeeded: %d\nskipped: %d\nfailed: %v\npending: %v\n", len(succeeded), len(skipped), failed, pending)
 	_ = os.WriteFile(summaryPath, []byte(summary), 0o644)
 
 	if len(pending) > 0 {
 		inspect("no CI checks still running",
 			false,
 			summaryPath,
-			strings.Join(pending, ", "))
+			strings.Join(pending, "; "))
 	}
 
 	inspect("all PR CI checks pass (no failures)",
-		len(failed) == 0,
+		len(failed) == 0 && len(succeeded) > 0,
 		summaryPath,
-		strings.Join(failed, ", "))
+		strings.Join(failed, "; "))
+
+	// CHECK 4 (optional): gh pr view when authenticated
+	ghOut, ghErr := run("gh", "pr", "view", prNumber, "--json", "state,title,statusCheckRollup")
+	ghPath := filepath.Join(outDir(), "gh-pr-view.json")
+	_ = os.WriteFile(ghPath, []byte(ghOut), 0o644)
+	if ghErr != nil || strings.Contains(ghOut, "HTTP 401") {
+		fmt.Printf("CHECK: gh pr view (optional)\n")
+		fmt.Printf("EVIDENCE: %s\n", ghPath)
+		fmt.Printf("RESULT: SKIP\n")
+		fmt.Printf("REASON: gh not authenticated; github-fetch ci used instead\n")
+	} else {
+		var pr prView
+		if err := json.Unmarshal([]byte(ghOut), &pr); err == nil {
+			inspect("PR state is OPEN (gh)",
+				strings.EqualFold(pr.State, "OPEN"),
+				pr.State,
+				"PR is not open")
+		}
+	}
 
 	fmt.Println("ALL CHECKS PASSED — PR #" + prNumber + " ready")
 }

--- a/test/integrations/as_unit_test_run/go_1_26_dual_patch_anchors_test.go
+++ b/test/integrations/as_unit_test_run/go_1_26_dual_patch_anchors_test.go
@@ -1,0 +1,47 @@
+package as_unit_test_run
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGo126FileBasedPatchesContainRequiredAnchors(t *testing.T) {
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// as_unit_test_run lives under test/integrations/as_unit_test_run
+	repoRoot := filepath.Clean(filepath.Join(root, "..", "..", ".."))
+
+	checks := []struct {
+		rel    string
+		must   []string
+	}{
+		{
+			rel: "cmd/xgo/asset/patches/go1.26/src/cmd/go/internal/work/exec.go.xgo.patch",
+			must: []string{"runCover", "__xgo_overlay_source_file"},
+		},
+		{
+			rel: "cmd/xgo/asset/patches/go1.26/src/cmd/go/internal/test/test.go.xgo.patch",
+			must: []string{"moduleLoaderState", "xgoModuleLoaderState"},
+		},
+		{
+			rel: "patches/go1.26/CHANGELOG",
+			must: []string{"omniaura/go1.26-support", "go1.27+"},
+		},
+	}
+	for _, c := range checks {
+		path := filepath.Join(repoRoot, c.rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", c.rel, err)
+		}
+		for _, needle := range c.must {
+			if !strings.Contains(string(data), needle) {
+				t.Fatalf("%s: missing %q", c.rel, needle)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Support go1.26 with dual legacy + file-based patch paths.

Incorporates go1.26-specific work from [@Peyton-Spencer](https://github.com/Peyton-Spencer)'s
[omniaura/go1.26-support](https://github.com/omniaura/xgo/tree/go1.26-support) branch
(commit `58f7584`) as legacy `instrument_go` handlers, coexisting with file-based
patches in `cmd/xgo/asset/patches/go1.26/`.

**Policy:** go1.26 is the last Go version with legacy instrument support; go1.27+ uses
file-based patches only.

Built on top of PR #387 work (CI green on `dev-go1.26`).