### PR TITLE
fix: eliminate DATA RACE on goroutine create inherit under -race

### DIFF
--- a/.github/workflows/race-canary.yml
+++ b/.github/workflows/race-canary.yml
@@ -1,0 +1,232 @@
+# Best-effort race bug capture on light/midweight open-source Go projects.
+#
+# Modes (parallel jobs):
+#   A) xgo test -race -count=1
+#   B) xgo test -race --trap-all -count=1
+#
+# Gate: RED only when the race detector reports DATA RACE with xgo frames
+# (github.com/xhd2015/xgo, __xgo_*, runtime/internal/{trap,stack,runtime}).
+# Third-party-only races, flakes, timeouts, and build failures are recorded
+# but do not fail the check.
+#
+# Projects: gin, chi, echo, cobra (no k8s/docker-class repos).
+name: Race Canary
+
+on:
+  schedule:
+    # Weekly Monday 03:17 UTC
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      dummy:
+        description: unused
+        default: nothing
+        required: false
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  race-canary:
+    name: race (${{ matrix.mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mode: default
+            extra_flags: ""
+          - mode: trap-all
+            extra_flags: "--trap-all"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: xgo
+
+      - name: Set up Go (latest stable release)
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install xgo
+        run: |
+          cd xgo
+          go install ./cmd/xgo
+          xgo exec --reset-instrument --log-debug go version
+          xgo revision
+          go version
+
+      - name: Prepare race-canary helpers
+        run: |
+          mkdir -p results logs
+          # Heredoc body must be unindented so the script is valid bash.
+          cat > run-project.sh <<'EOF'
+          #!/usr/bin/env bash
+          # Usage: bash run-project.sh <name> <dir>
+          # Optional env EXTRA_FLAGS (e.g. --trap-all).
+          # Records results/<name>.{status,exit}; tees logs/<name>.log
+          # status: ok | race | race-external | fail | build
+          set -u
+          name="$1"
+          dir="$2"
+          # shellcheck disable=SC2206
+          extra_flags=( ${EXTRA_FLAGS:-} )
+          log="logs/${name}.log"
+          status_file="results/${name}.status"
+          exit_file="results/${name}.exit"
+
+          mkdir -p logs results
+          echo "=== race-canary: ${name} ===" | tee "$log"
+          echo "dir=${dir} flags=-race -count=1 ${extra_flags[*]:-}" | tee -a "$log"
+
+          set +e
+          (
+            cd "$dir" || exit 99
+            xgo test -race -count=1 "${extra_flags[@]}" ./...
+          ) 2>&1 | tee -a "$log"
+          exit_code=${PIPESTATUS[0]}
+          set -e
+
+          echo "$exit_code" > "$exit_file"
+
+          if grep -qE 'WARNING: DATA RACE|Found [0-9]+ data race' "$log"; then
+            # Hard-fail only races that involve xgo frames (runtime/trap/stack or
+            # __xgo_ symbols). Third-party-only races are recorded as warnings so
+            # canary noise from gin/chi/echo/cobra does not red the job when xgo
+            # did not participate in the race stacks.
+            if grep -qE 'github\.com/xhd2015/xgo|/runtime/internal/(trap|stack|runtime)|__xgo_|xgo_trap' "$log"; then
+              echo race > "$status_file"
+              echo "::error title=DATA RACE xgo (${name})::Race detector reported DATA RACE with xgo frames in ${name}"
+            else
+              echo race-external > "$status_file"
+              echo "::warning title=DATA RACE external (${name})::Race detector reported DATA RACE without xgo frames in ${name} (non-gating)"
+            fi
+          elif grep -qiE 'build failed|error:.*instrument' "$log" && [[ "$exit_code" -ne 0 ]]; then
+            # Best-effort build/instrument classification; still non-gating.
+            echo build > "$status_file"
+            echo "::warning title=build/instrument (${name})::non-zero exit with build-like log (exit ${exit_code})"
+          elif [[ "$exit_code" -ne 0 ]]; then
+            echo fail > "$status_file"
+            echo "::warning title=test fail (${name})::exit ${exit_code} (no DATA RACE)"
+          else
+            echo ok > "$status_file"
+          fi
+
+          echo "status=$(cat "$status_file") exit=$(cat "$exit_file")" | tee -a "$log"
+          # Never fail here — gate is applied in "Fail if DATA RACE" step.
+          exit 0
+          EOF
+          # Strip YAML-style leading indent from the generated script (8 spaces).
+          sed -i 's/^          //' run-project.sh
+          chmod +x run-project.sh
+          head -3 run-project.sh
+
+      # --- projects (serial; race is memory-heavy) ---
+
+      - uses: actions/checkout@v4
+        with:
+          repository: gin-gonic/gin
+          path: gin-gonic/gin
+
+      - name: Test gin-gonic/gin
+        env:
+          EXTRA_FLAGS: ${{ matrix.extra_flags }}
+        run: bash run-project.sh gin gin-gonic/gin
+
+      - uses: actions/checkout@v4
+        with:
+          repository: go-chi/chi
+          path: go-chi/chi
+
+      - name: Test go-chi/chi
+        env:
+          EXTRA_FLAGS: ${{ matrix.extra_flags }}
+        run: bash run-project.sh chi go-chi/chi
+
+      - uses: actions/checkout@v4
+        with:
+          repository: labstack/echo
+          path: labstack/echo
+
+      - name: Test labstack/echo
+        env:
+          EXTRA_FLAGS: ${{ matrix.extra_flags }}
+        run: bash run-project.sh echo labstack/echo
+
+      - uses: actions/checkout@v4
+        with:
+          repository: spf13/cobra
+          path: spf13/cobra
+
+      - name: Test spf13/cobra
+        env:
+          EXTRA_FLAGS: ${{ matrix.extra_flags }}
+        run: bash run-project.sh cobra spf13/cobra
+
+      - name: Summary
+        if: always()
+        run: |
+          mode="${{ matrix.mode }}"
+          {
+            echo "## Race canary — mode=\`${mode}\`"
+            echo ""
+            echo "| Project | Status | Exit |"
+            echo "|---------|--------|------|"
+            for name in gin chi echo cobra; do
+              st="missing"
+              ex="?"
+              [[ -f "results/${name}.status" ]] && st=$(cat "results/${name}.status")
+              [[ -f "results/${name}.exit" ]] && ex=$(cat "results/${name}.exit")
+              echo "| ${name} | ${st} | ${ex} |"
+            done
+            echo ""
+            echo "Gate: workflow fails only when status is \`race\` (DATA RACE with xgo frames)."
+            echo "\`race-external\` = third-party-only race (warning, non-blocking)."
+            echo "Other non-zero exits are best-effort (recorded, non-blocking)."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "---- results ----"
+          ls -la results logs || true
+          for name in gin chi echo cobra; do
+            echo -n "${name}: "
+            cat "results/${name}.status" 2>/dev/null || echo missing
+          done
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: race-canary-${{ matrix.mode }}
+          path: |
+            logs/
+            results/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Fail if DATA RACE (xgo frames)
+        if: always()
+        run: |
+          race_found=0
+          external_found=0
+          for f in results/*.status; do
+            [[ -f "$f" ]] || continue
+            st=$(cat "$f")
+            if [[ "$st" == "race" ]]; then
+              echo "DATA RACE (xgo) marker: $f"
+              race_found=1
+            elif [[ "$st" == "race-external" ]]; then
+              echo "DATA RACE (external, non-gating) marker: $f"
+              external_found=1
+            fi
+          done
+          if [[ "$race_found" -eq 1 ]]; then
+            echo "Failing job: at least one project reported DATA RACE with xgo frames under mode=${{ matrix.mode }}"
+            exit 1
+          fi
+          if [[ "$external_found" -eq 1 ]]; then
+            echo "External-only DATA RACE present; job stays green (non-gating)."
+          fi
+          echo "No xgo DATA RACE markers; job green (best-effort for other failures)."
+          exit 0

--- a/cmd/xgo/asset/patches/go1.24/src/runtime/proc.go.xgo.patch
+++ b/cmd/xgo/asset/patches/go1.24/src/runtime/proc.go.xgo.patch
@@ -9,13 +9,26 @@ insert_before __xgo_curg := gp.m.curg;var __xgo_newg *g;
 </patch>
 
 <patch add_go_newproc_callback_v2>
-# Description: Add __xgo_callback_on_create_g call after newproc1 creates a goroutine.
-# Wraps the newproc1 call to save newg and invoke the callback.
-# Replaces: newg := newproc1(fn, gp, pc, false, waitReasonZero)
-# With extra wrapping that saves __xgo_newg and calls the create callback.
+# Description: Add __xgo_callback_on_create_g after newproc1, then set up race
+# context, then continue scheduling. Race setup must run AFTER the create
+# callback so parent writes to child __xgo_g happen-before racegostart
+# (issues #341 / #330). Callback stays off systemstack.
 goto func newproc
 	match waitReasonZero)
-	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;
+	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };
+</patch>
+
+<patch xgo_proc_defer_racegostart>
+# Description: Skip racegostart inside newproc1; it is re-run in newproc after
+# the xgo create callback so inherit writes are ordered before the race
+# detector's go happens-before edge.
+# Anchor on racegostart, then replace the last preceding if raceenabled
+# (decoy-safe). Stronger than the legacy live SequenceOffset path in
+# instrument_runtime/proc.go.
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
 </patch>
 
 <patch add_go_exit1_callback>

--- a/cmd/xgo/asset/patches/go1.24/src/runtime/xgo_trap.go.txt
+++ b/cmd/xgo/asset/patches/go1.24/src/runtime/xgo_trap.go.txt
@@ -238,15 +238,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/cmd/xgo/asset/patches/go1.25/src/runtime/proc.go.xgo.patch
+++ b/cmd/xgo/asset/patches/go1.25/src/runtime/proc.go.xgo.patch
@@ -12,13 +12,27 @@ newline
 </patch>
 
 <patch xgo_proc_newproc_callback>
-# Description: Add __xgo_callback_on_create_g call after newproc1 creates a goroutine.
-# Wraps the newproc1 call to save newg and invoke the callback.
-# Replaces: newg := newproc1(fn, gp, pc, false, waitReasonZero)
-# With extra wrapping that saves __xgo_newg and calls the create callback.
+# Description: Add __xgo_callback_on_create_g after newproc1, then set up race
+# context, then continue scheduling. Race setup must run AFTER the create
+# callback so parent writes to child __xgo_g happen-before racegostart
+# (issues #341 / #330). Callback stays off systemstack.
+# Wraps: newg := newproc1(fn, gp, pc, false, waitReasonZero)
 goto func newproc
 	match waitReasonZero)
-	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;
+	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };
+</patch>
+
+<patch xgo_proc_defer_racegostart>
+# Description: Skip racegostart inside newproc1; it is re-run in newproc after
+# the xgo create callback so inherit writes are ordered before the race
+# detector's go happens-before edge.
+# Anchor on racegostart, then replace the last preceding if raceenabled
+# (decoy-safe). Stronger than the legacy live SequenceOffset path in
+# instrument_runtime/proc.go.
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
 </patch>
 
 <patch xgo_proc_goexit1>

--- a/cmd/xgo/asset/patches/go1.25/src/runtime/xgo_trap.go.txt
+++ b/cmd/xgo/asset/patches/go1.25/src/runtime/xgo_trap.go.txt
@@ -238,15 +238,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/cmd/xgo/asset/patches/go1.26/src/runtime/proc.go.xgo.patch
+++ b/cmd/xgo/asset/patches/go1.26/src/runtime/proc.go.xgo.patch
@@ -12,13 +12,27 @@ newline
 </patch>
 
 <patch xgo_proc_newproc_callback>
-# Description: Add __xgo_callback_on_create_g call after newproc1 creates a goroutine.
-# Wraps the newproc1 call to save newg and invoke the callback.
-# Replaces: newg := newproc1(fn, gp, pc, false, waitReasonZero)
-# With extra wrapping that saves __xgo_newg and calls the create callback.
+# Description: Add __xgo_callback_on_create_g after newproc1, then set up race
+# context, then continue scheduling. Race setup must run AFTER the create
+# callback so parent writes to child __xgo_g happen-before racegostart
+# (issues #341 / #330). Callback stays off systemstack.
+# Wraps: newg := newproc1(fn, gp, pc, false, waitReasonZero)
 goto func newproc
 	match waitReasonZero)
-	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;
+	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };
+</patch>
+
+<patch xgo_proc_defer_racegostart>
+# Description: Skip racegostart inside newproc1; it is re-run in newproc after
+# the xgo create callback so inherit writes are ordered before the race
+# detector's go happens-before edge.
+# Anchor on racegostart, then replace the last preceding if raceenabled
+# (decoy-safe). Stronger than the legacy live SequenceOffset path in
+# instrument_runtime/proc.go.
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
 </patch>
 
 <patch xgo_proc_goexit1>

--- a/cmd/xgo/asset/patches/go1.26/src/runtime/xgo_trap.go.txt
+++ b/cmd/xgo/asset/patches/go1.26/src/runtime/xgo_trap.go.txt
@@ -238,15 +238,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/cmd/xgo/asset/patches/go1.27/src/runtime/proc.go.xgo.patch
+++ b/cmd/xgo/asset/patches/go1.27/src/runtime/proc.go.xgo.patch
@@ -12,13 +12,27 @@ newline
 </patch>
 
 <patch xgo_proc_newproc_callback>
-# Description: Add __xgo_callback_on_create_g call after newproc1 creates a goroutine.
-# Wraps the newproc1 call to save newg and invoke the callback.
-# Replaces: newg := newproc1(fn, gp, pc, false, waitReasonZero)
-# With extra wrapping that saves __xgo_newg and calls the create callback.
+# Description: Add __xgo_callback_on_create_g after newproc1, then set up race
+# context, then continue scheduling. Race setup must run AFTER the create
+# callback so parent writes to child __xgo_g happen-before racegostart
+# (issues #341 / #330). Callback stays off systemstack.
+# Wraps: newg := newproc1(fn, gp, pc, false, waitReasonZero)
 goto func newproc
 	match waitReasonZero)
-	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;
+	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };
+</patch>
+
+<patch xgo_proc_defer_racegostart>
+# Description: Skip racegostart inside newproc1; it is re-run in newproc after
+# the xgo create callback so inherit writes are ordered before the race
+# detector's go happens-before edge.
+# Anchor on racegostart, then replace the last preceding if raceenabled
+# (decoy-safe). Stronger than the legacy live SequenceOffset path in
+# instrument_runtime/proc.go.
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
 </patch>
 
 <patch xgo_proc_goexit1>

--- a/cmd/xgo/asset/patches/go1.27/src/runtime/xgo_trap.go.txt
+++ b/cmd/xgo/asset/patches/go1.27/src/runtime/xgo_trap.go.txt
@@ -238,15 +238,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/cmd/xgo/asset/runtime_gen/internal/runtime/xgo_trap_template.go
+++ b/cmd/xgo/asset/runtime_gen/internal/runtime/xgo_trap_template.go
@@ -239,15 +239,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/cmd/xgo/asset/runtime_gen/internal/stack/export.go
+++ b/cmd/xgo/asset/runtime_gen/internal/stack/export.go
@@ -13,10 +13,13 @@ func Export(stack *Stack, offsetNS int64) *stack_model.Stack {
 	if stack == nil {
 		return nil
 	}
+	// Snapshot under the stack mutex so concurrent Push/Finish cannot race
+	// with the export walk (Phase 1 race fix).
+	begin, _, roots := stack.Snapshot()
 	return &stack_model.Stack{
 		Format:   "stack",
-		Begin:    stack.Begin.Format(time.RFC3339),
-		Children: ExportStackEntries(stack.Roots, stack.Begin, offsetNS),
+		Begin:    begin.Format(time.RFC3339),
+		Children: ExportStackEntries(roots, begin, offsetNS),
 	}
 }
 
@@ -39,23 +42,26 @@ func ExportStackEntry(entry *Entry, rootBegin time.Time, offsetNS int64) *stack_
 	var isRunning bool
 	children := ExportStackEntries(entry.Children, rootBegin, offsetNS)
 	beginNs := entry.BeginNs + offsetNS
-	// stackEndNs := entry.EndNs
 	endNs := entry.EndNs + offsetNS
 	fnInfo := ExportFuncInfo(entry)
 	if entry.Go && entry.GetStack != nil {
 		if !flags.XGO_RACE_SAFE {
-			// handle async stack
-			stack := entry.GetStack()
-			if stack != nil {
-				// NOTE: this might be unsafe since the
-				// child goroutine might be running
-				exportedStack := Export(stack, beginNs)
-				children = append(children, exportedStack.Children...)
-				if stack.End.IsZero() {
+			// Child stack is snapshotted under its own mutex inside Export /
+			// Snapshot — safe if the child is still running.
+			childStack := entry.GetStack()
+			if childStack != nil {
+				childBegin, childEnd, childRoots := childStack.Snapshot()
+				exportedChildren := ExportStackEntries(childRoots, childBegin, beginNs)
+				children = append(children, exportedChildren...)
+				// Prefer zero-value compare over IsZero(): time.Time methods can
+				// be instrumented under --trap-stdlib / --trap-all and re-enter
+				// trap/export (see SetEndIfZero). Safe outside mu, but keep
+				// export free of instrumentable time methods.
+				if childEnd == (time.Time{}) {
 					isRunning = true
-					endNs = runtime.XgoRealTimeNow().UnixNano() - stack.Begin.UnixNano() + beginNs
+					endNs = runtime.XgoRealTimeNow().UnixNano() - childBegin.UnixNano() + beginNs
 				} else {
-					endNs = stack.End.UnixNano() - stack.Begin.UnixNano() + beginNs
+					endNs = childEnd.UnixNano() - childBegin.UnixNano() + beginNs
 				}
 			}
 		} else {

--- a/cmd/xgo/asset/runtime_gen/internal/stack/stack.go
+++ b/cmd/xgo/asset/runtime_gen/internal/stack/stack.go
@@ -1,12 +1,23 @@
 package stack
 
 import (
+	"sync"
 	"time"
 
 	"github.com/xhd2015/xgo/runtime/core"
 )
 
+// Stack is a per-goroutine call tree. All tree mutations and export snapshots
+// go through mu so concurrent Push (child) vs Export (parent) is race-free
+// under -race (see race_export / issue #341 follow-up Phase 1).
+//
+// IMPORTANT: never call instrumented functions (e.g. time.Time methods that
+// may trap) while holding mu — trap re-enters GetData and deadlocks.
 type Stack struct {
+	mu sync.Mutex
+
+	// Begin is fixed after stack creation; safe to read without mu for
+	// computing relative nanoseconds outside the lock.
 	Begin      time.Time
 	End        time.Time
 	MaxEntryID int
@@ -73,6 +84,14 @@ func Detach() {
 
 // push returns the old top
 func (c *Stack) Push(cur *Entry) *Entry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pushLocked(cur)
+}
+
+func (c *Stack) pushLocked(cur *Entry) *Entry {
+	// Historical behavior: Push bumps MaxEntryID even though Entry.ID was
+	// already assigned in NewEntry.
 	c.MaxEntryID++
 	oldTop := c.Top
 	if oldTop == nil {
@@ -86,13 +105,96 @@ func (c *Stack) Push(cur *Entry) *Entry {
 }
 
 func (c *Stack) NewEntry(begin time.Time, fnName string) *Entry {
+	// Compute relative time outside the lock (time methods may trap).
+	beginNs := begin.UnixNano() - c.Begin.UnixNano()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.newEntryLocked(beginNs, fnName)
+}
+
+func (c *Stack) newEntryLocked(beginNs int64, fnName string) *Entry {
 	c.MaxEntryID++
-	cur := &Entry{
+	return &Entry{
 		ID:       c.MaxEntryID,
 		FuncName: fnName,
-		BeginNs:  begin.UnixNano() - c.Begin.UnixNano(),
+		BeginNs:  beginNs,
 	}
-	return cur
+}
+
+// PushNew creates an entry, pushes it, runs setup, and increments Depth under
+// one lock so the tree is never observed half-updated by Export.
+// MaxEntryID is bumped twice (newEntry + push), matching historical NewEntry+Push.
+func (c *Stack) PushNew(begin time.Time, fnName string, setup func(*Entry)) (cur *Entry, oldTop *Entry) {
+	beginNs := begin.UnixNano() - c.Begin.UnixNano()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cur = c.newEntryLocked(beginNs, fnName)
+	oldTop = c.pushLocked(cur)
+	if setup != nil {
+		setup(cur)
+	}
+	c.Depth++
+	return cur, oldTop
+}
+
+// Finish completes an entry, restores Top, decrements Depth under lock.
+// finish must not call instrumented functions (no time.Time methods, no traps).
+func (c *Stack) Finish(cur *Entry, oldTop *Entry, end time.Time, setStackEnd bool, finish func(*Entry)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if setStackEnd {
+		c.End = end
+	}
+	if finish != nil {
+		finish(cur)
+	}
+	c.Top = oldTop
+	c.Depth--
+}
+
+// AppendGoChild attaches a synthetic "go" node under the current Top under lock.
+func (c *Stack) AppendGoChild(beginNs int64, getStack func() *Stack) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Top == nil {
+		return
+	}
+	child := &Entry{
+		BeginNs:  beginNs,
+		Go:       true,
+		FuncName: "go",
+		GetStack: getStack,
+	}
+	c.Top.Children = append(c.Top.Children, child)
+}
+
+// SetEndIfZero records stack end time once (goroutine exit).
+func (c *Stack) SetEndIfZero(t time.Time) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Do not call time.Time methods (e.g. IsZero) while holding mu — they are
+	// instrumented and re-enter trap → GetData → same mutex (deadlock).
+	if c.End == (time.Time{}) {
+		c.End = t
+	}
+}
+
+// Snapshot copies the tree for race-free export. GetStack funcs still point at
+// the live Stack; callers Export those under their own locks.
+// Must not invoke instrumented code while holding mu.
+func (c *Stack) Snapshot() (begin, end time.Time, roots []*Entry) {
+	if c == nil {
+		return time.Time{}, time.Time{}, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.Begin, c.End, cloneEntries(c.Roots)
 }
 
 type Field struct {
@@ -114,12 +216,42 @@ func (s *Entry) GetData(key interface{}) interface{} {
 type StackArgs []interface{}
 
 func (c *Stack) GetData(key interface{}) interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.Data[key]
 }
 
 func (c *Stack) SetData(key, value interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.Data == nil {
 		c.Data = make(map[interface{}]interface{}, 1)
 	}
 	c.Data[key] = value
+}
+
+func cloneEntries(entries []*Entry) []*Entry {
+	if entries == nil {
+		return nil
+	}
+	out := make([]*Entry, len(entries))
+	for i, e := range entries {
+		out[i] = cloneEntry(e)
+	}
+	return out
+}
+
+func cloneEntry(e *Entry) *Entry {
+	if e == nil {
+		return nil
+	}
+	cp := *e
+	cp.Children = cloneEntries(e.Children)
+	if e.Data != nil {
+		cp.Data = make(EntryData, len(e.Data))
+		for k, v := range e.Data {
+			cp.Data[k] = v
+		}
+	}
+	return &cp
 }

--- a/cmd/xgo/asset/runtime_gen/internal/trap/init.go
+++ b/cmd/xgo/asset/runtime_gen/internal/trap/init.go
@@ -17,14 +17,12 @@ func init() {
 	})
 	runtime.XgoOnExitG(func() {
 		g := stack.GetG()
-		stack := g.GetStack()
-		if stack == nil {
+		stk := g.GetStack()
+		if stk == nil {
 			return
 		}
-		if stack.End.IsZero() {
-			// fill end
-			stack.End = runtime.XgoRealTimeNow()
-		}
+		// fill end under stack mutex (export may snapshot concurrently)
+		stk.SetEndIfZero(runtime.XgoRealTimeNow())
 	})
 }
 
@@ -64,17 +62,10 @@ func inerhitStack(curG stack.G, newG stack.G) {
 		newStackData.hasStartedTracing = true
 		newStackData.filterTrace = stackData.filterTrace
 
-		if curStack.Top != nil {
-			child := &stack.Entry{
-				BeginNs:  newStack.Begin.Sub(curStack.Begin).Nanoseconds(),
-				Go:       true,
-				FuncName: "go",
-				GetStack: func() *stack.Stack {
-					return newStack
-				},
-			}
-			curStack.Top.Children = append(curStack.Top.Children, child)
-		}
+		// Append under parent stack mutex so Export cannot race with Push/Top.
+		curStack.AppendGoChild(newStack.Begin.Sub(curStack.Begin).Nanoseconds(), func() *stack.Stack {
+			return newStack
+		})
 	}
 }
 

--- a/cmd/xgo/asset/runtime_gen/internal/trap/trap.go
+++ b/cmd/xgo/asset/runtime_gen/internal/trap/trap.go
@@ -255,12 +255,7 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 	//
 	//
 	// === tracing records ===
-	file, line := runtimeFuncInfo.FileLine(pc)
-	cur := stk.NewEntry(begin, name)
-	oldTop := stk.Push(cur)
-	cur.File = file
-	cur.Line = line
-	cur.FuncInfo = funcInfo
+	callFile, callLine := runtimeFuncInfo.FileLine(pc)
 
 	if isStartTracing && !isTesting {
 		var onFinish func(stack stack_model.IStack)
@@ -281,9 +276,8 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 			if rvalue.IsValid() && rvalue.Kind() == reflect.Struct {
 				outputFileField := rvalue.FieldByName("OutputFile")
 				if outputFileField.IsValid() {
-					file, ok := outputFileField.Interface().(string)
-					if ok {
-						outputFile = file
+					if f, ok := outputFileField.Interface().(string); ok {
+						outputFile = f
 					}
 				}
 				onFinishField := rvalue.FieldByName("OnFinish")
@@ -325,8 +319,15 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 		copy(marshalNames[1:], argNamesNoCtx)
 		copy(marshalArgs[1:], argsNoCtx)
 	}
-	cur.Args = json.RawMessage(xgo_runtime.MarshalNoError(newStructValue(marshalNames, marshalArgs)))
-	stk.Depth++
+	argsJSON := json.RawMessage(xgo_runtime.MarshalNoError(newStructValue(marshalNames, marshalArgs)))
+
+	// Push under stack mutex so Export cannot observe a half-built entry.
+	cur, oldTop := stk.PushNew(begin, name, func(cur *stack.Entry) {
+		cur.File = callFile
+		cur.Line = callLine
+		cur.FuncInfo = funcInfo
+		cur.Args = argsJSON
+	})
 
 	var hitMock bool
 	post := func() {
@@ -343,16 +344,15 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 		// see https://github.com/xhd2015/xgo/issues/307
 		// so we add a standalone flag `Finished`
 		end := xgo_runtime.XgoRealTimeNow()
-		if isStartTracing {
-			stk.End = end
-		}
-		cur.EndNs = end.UnixNano() - stk.Begin.UnixNano()
-		cur.Finished = true
-		cur.HitMock = hitMock
+
+		// Compute post fields outside the lock when possible; panic line needs
+		// runtime.Callers which must not run while holding stack.mu if export
+		// also takes locks in other orders (export only locks stacks).
 		var hasPanic bool
+		var panicLine int
+		var errStr string
 		if pe, retpc := xgo_runtime.XgoPeekPanic(); pe != nil {
 			hasPanic = true
-			cur.Panic = true
 			// frame:
 			//   0: trap.trap
 			//   1: runtime.gopanic
@@ -389,21 +389,35 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 				entryPC := runtime.FuncForPC(pc).Entry()
 				if entryPC == retEntryPC {
 					frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
-					cur.PanicLine = frame.Line
+					panicLine = frame.Line
 					break
 				}
 			}
-			cur.Error = fmt.Sprint(pe)
+			errStr = fmt.Sprint(pe)
 		}
 
 		resultNamesNoErr, resultsNoErr, resErr := trySplitLastError(resultNames, results)
-		cur.Results = json.RawMessage(xgo_runtime.MarshalNoError(newStructValue(resultNamesNoErr, resultsNoErr)))
+		resultsJSON := json.RawMessage(xgo_runtime.MarshalNoError(newStructValue(resultNamesNoErr, resultsNoErr)))
 		if !hasPanic && resErr != nil {
-			cur.Error = resErr.Error()
+			errStr = resErr.Error()
 		}
 
-		stk.Top = oldTop
-		stk.Depth--
+		// Relative end time outside lock (time methods may trap / deadlock).
+		endNs := end.UnixNano() - stk.Begin.UnixNano()
+		// finish under lock: entry fields + Top/Depth for race-free export
+		stk.Finish(cur, oldTop, end, isStartTracing, func(cur *stack.Entry) {
+			cur.EndNs = endNs
+			cur.Finished = true
+			cur.HitMock = hitMock
+			if hasPanic {
+				cur.Panic = true
+				cur.PanicLine = panicLine
+			}
+			cur.Results = resultsJSON
+			if errStr != "" {
+				cur.Error = errStr
+			}
+		})
 		if isStartTracing {
 			exportedStack := stack.Export(stk, 0)
 			if isTesting {

--- a/cmd/xgo/asset/runtime_gen/internal/trap/var.go
+++ b/cmd/xgo/asset/runtime_gen/internal/trap/var.go
@@ -148,12 +148,18 @@ func doTrapVar(funcInfo *core.FuncInfo, stk *stack.Stack, begin time.Time, traci
 		return
 	}
 	_, file, line, _ := runtime.Caller(SKIP + 2)
-	cur := stk.NewEntry(begin, funcInfo.Name)
-	cur.File = file
-	cur.Line = line
-	cur.FuncInfo = funcInfo
-	cur.Results = json.RawMessage(xgo_runtime.MarshalNoError(res))
-	stk.Top = stk.Push(cur)
-	cur.EndNs = xgo_runtime.XgoRealTimeNow().UnixNano() - stk.Begin.UnixNano()
-	cur.Finished = true
+	end := xgo_runtime.XgoRealTimeNow()
+	endNs := end.UnixNano() - stk.Begin.UnixNano()
+	resultsJSON := json.RawMessage(xgo_runtime.MarshalNoError(res))
+	// Single locked push+finish so export cannot race with var trap records.
+	cur, oldTop := stk.PushNew(begin, funcInfo.Name, func(cur *stack.Entry) {
+		cur.File = file
+		cur.Line = line
+		cur.FuncInfo = funcInfo
+		cur.Results = resultsJSON
+	})
+	stk.Finish(cur, oldTop, end, false, func(cur *stack.Entry) {
+		cur.EndNs = endNs
+		cur.Finished = true
+	})
 }

--- a/instrument/instrument_runtime/proc.go
+++ b/instrument/instrument_runtime/proc.go
@@ -1,6 +1,8 @@
 package instrument_runtime
 
 import (
+	"strings"
+
 	"github.com/xhd2015/xgo/instrument/instrument_runtime/template"
 	"github.com/xhd2015/xgo/instrument/patch"
 	"github.com/xhd2015/xgo/support/goinfo"
@@ -59,6 +61,17 @@ func instrumentNewGroutineV2(goVersion *goinfo.GoVersion, procContent string) (s
 		patch.UpdatePosition_Before,
 		"__xgo_curg := gp.m.curg;var __xgo_newg *g;",
 	)
+
+	// Create callback runs off systemstack. Race context must be set up AFTER
+	// the callback so parent writes to child __xgo_g happen-before racegostart
+	// (see https://github.com/xhd2015/xgo/issues/341).
+	//
+	// The raceenabled block body differs by Go version:
+	// - go1.17–1.18: racegostart only
+	// - go1.19 early: racegostart + labels release
+	// - go1.19.13+/1.20+: racegostart + raceignore + labels release
+	// Detect which pieces exist in newproc1 so we re-emit a compiling block.
+	raceSetupAfterCallback := buildRaceSetupAfterCreateCallback(procContent)
 	procContent = patch.UpdateContent(procContent,
 		"/*<begin add_go_newproc_callback_v2>*/",
 		"/*<end add_go_newproc_callback_v2>*/",
@@ -72,10 +85,70 @@ func instrumentNewGroutineV2(goVersion *goinfo.GoVersion, procContent string) (s
 		},
 		2,
 		patch.UpdatePosition_After,
-		// avoid executing xgo code on system stack
-		";__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;",
+		";__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;"+raceSetupAfterCallback,
+	)
+
+	// Disable race setup inside newproc1 (moved after create callback above).
+	// Anchor without relying on "// Set up race context." (added only in go1.22+).
+	//
+	// Anchoring note (legacy path; not upgraded further):
+	// SequenceOffset takes the first "if raceenabled {" after "func newproc1(",
+	// then requires "racegostart(" later. That is enough for stock Go, which has a
+	// single raceenabled block owning racegostart. It is weaker than the file-based
+	// patch (match racegostart → find_for_replace last preceding if raceenabled),
+	// which survives an earlier decoy if raceenabled. Prefer that DSL if newproc1
+	// gains multiple raceenabled blocks; this live path is outdated relative to it.
+	// See instrument/patch apply_engine evalMatch(forReplace) and
+	// TestApplyPatch_DeferRacegostartAnchorsOnRacegostart.
+	procContent = patch.UpdateContent(procContent,
+		"/*<begin xgo_proc_defer_racegostart>*/",
+		"/*<end xgo_proc_defer_racegostart>*/",
+		[]string{
+			"func newproc1(",
+			"if raceenabled {",
+			"racegostart(",
+		},
+		1,
+		patch.UpdatePosition_Replace,
+		"if false { // xgo: race setup moved after create callback (#341)",
 	)
 	return procContent, nil
+}
+
+// buildRaceSetupAfterCreateCallback returns an inlined race-setup statement
+// that matches the original newproc1 raceenabled block for this GOROOT.
+func buildRaceSetupAfterCreateCallback(procContent string) string {
+	// Minimal setup present since early race support.
+	// pc is newproc's caller PC (GetCallerPC / getcallerpc).
+	setup := "if raceenabled { newg.racectx = racegostart(pc);"
+	// raceignore was added mid-go1.19 (present in go1.19.13+, not in go1.19.0).
+	if containsInFunc(procContent, "func newproc1(", "newg.raceignore") {
+		setup += " newg.raceignore = 0;"
+	}
+	// labels release present from go1.19+.
+	if containsInFunc(procContent, "func newproc1(", "racereleasemergeg(newg") {
+		setup += " if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) };"
+	}
+	setup += " };"
+	return setup
+}
+
+// containsInFunc reports whether needle appears inside the Go function that
+// starts at startMark (e.g. "func newproc1("). The scan stops at the next
+// top-level "\nfunc " (or EOF), so later unrelated occurrences cannot flip
+// feature detection for race setup emission.
+func containsInFunc(content, startMark, needle string) bool {
+	idx := strings.Index(content, startMark)
+	if idx < 0 {
+		return false
+	}
+	rest := content[idx:]
+	// Skip past startMark so we do not match a nested/next "func " incorrectly.
+	nextRel := strings.Index(rest[len(startMark):], "\nfunc ")
+	if nextRel < 0 {
+		return strings.Contains(rest, needle)
+	}
+	return strings.Contains(rest[:len(startMark)+nextRel], needle)
 }
 
 func instrumentInitFinished(content string) string {

--- a/instrument/instrument_runtime/proc_test.go
+++ b/instrument/instrument_runtime/proc_test.go
@@ -1,0 +1,120 @@
+package instrument_runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+// Representative newproc1 race-setup snippets (not full runtime files).
+// Shape mirrors go1.18 / mid-1.19 / 1.20+ as used by buildRaceSetupAfterCreateCallback.
+const (
+	snippetGo118 = `
+func newproc1(fn *funcval, callergp *g, callerpc uintptr) *g {
+	// ... body ...
+	if raceenabled {
+		newg.racectx = racegostart(callerpc)
+	}
+	return newg
+}
+
+func saveAncestors(callergp *g) *[]ancestorInfo {
+	// decoy: must not affect detection of raceignore / labels release
+	newg.raceignore = 0
+	racereleasemergeg(newg, unsafe.Pointer(&labelSync))
+	return nil
+}
+`
+
+	snippetGo119Early = `
+func newproc1(fn *funcval, callergp *g, callerpc uintptr) *g {
+	if raceenabled {
+		newg.racectx = racegostart(callerpc)
+		// early 1.19: labels release but no raceignore field write
+		if newg.labels != nil {
+			racereleasemergeg(newg, unsafe.Pointer(&labelSync))
+		}
+	}
+	return newg
+}
+
+func other() {
+	newg.raceignore = 0 // decoy after newproc1
+}
+`
+
+	snippetGo120Plus = `
+func newproc1(fn *funcval, callergp *g, callerpc uintptr) *g {
+	// Set up race context.
+	if raceenabled {
+		newg.racectx = racegostart(callerpc)
+		newg.raceignore = 0
+		if newg.labels != nil {
+			// See note in proflabel.go on labelSync's role
+			racereleasemergeg(newg, unsafe.Pointer(&labelSync))
+		}
+	}
+	return newg
+}
+
+func saveAncestors(callergp *g) *[]ancestorInfo {
+	return nil
+}
+`
+)
+
+func TestBuildRaceSetupAfterCreateCallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		snippet string
+		want    string
+	}{
+		{
+			name:    "go1.18 racegostart only",
+			snippet: snippetGo118,
+			want:    "if raceenabled { newg.racectx = racegostart(pc); };",
+		},
+		{
+			name:    "go1.19 early labels without raceignore",
+			snippet: snippetGo119Early,
+			want:    "if raceenabled { newg.racectx = racegostart(pc); if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };",
+		},
+		{
+			name:    "go1.20+ full block",
+			snippet: snippetGo120Plus,
+			want:    "if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRaceSetupAfterCreateCallback(tt.snippet)
+			if got != tt.want {
+				t.Fatalf("setup mismatch\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsInFuncBoundsToFunctionBody(t *testing.T) {
+	// Decoy after newproc1 must not count.
+	if containsInFunc(snippetGo118, "func newproc1(", "newg.raceignore") {
+		t.Fatal("expected raceignore decoy after newproc1 to be ignored")
+	}
+	if containsInFunc(snippetGo118, "func newproc1(", "racereleasemergeg(newg") {
+		t.Fatal("expected racereleasemergeg decoy after newproc1 to be ignored")
+	}
+	if !containsInFunc(snippetGo120Plus, "func newproc1(", "newg.raceignore") {
+		t.Fatal("expected raceignore inside newproc1 body")
+	}
+	if containsInFunc("func other() {}", "func newproc1(", "racegostart") {
+		t.Fatal("missing start mark should be false")
+	}
+}
+
+func TestContainsInFuncEOFWhenNoNextFunc(t *testing.T) {
+	only := "func newproc1() {\n\tnewg.raceignore = 0\n}\n"
+	// trailing content without \nfunc
+	only = strings.TrimSuffix(only, "\n") + "\n// end of file\n"
+	if !containsInFunc(only, "func newproc1(", "newg.raceignore") {
+		t.Fatal("expected match when no next func and needle in body")
+	}
+}

--- a/instrument/patch/apply_engine.go
+++ b/instrument/patch/apply_engine.go
@@ -514,6 +514,12 @@ func (s *applyState) findNodeAt(node ast.Node, pos token.Pos) ast.Node {
 }
 
 // evalMatch finds text within the current scope and returns a cursor.
+//
+// When forReplace is true and the cursor already sits past the start of the
+// current scope (e.g. after `match racegostart(`), prefer the last occurrence
+// of searchText before the cursor. That lets patches anchor on a unique
+// following marker and replace the preceding line without matching an earlier
+// decoy in the same function (see xgo_proc_defer_racegostart).
 func evalMatch(state *applyState, searchText string, forReplace bool) (cursor, error) {
 	// Determine search scope
 	scopeStart := 0
@@ -523,6 +529,18 @@ func evalMatch(state *applyState, searchText string, forReplace bool) (cursor, e
 	if node != nil && node != state.astFile {
 		scopeStart = state.fset.Position(node.Pos()).Offset
 		scopeEnd = state.fset.Position(node.End()).Offset
+	}
+
+	if forReplace && state.cursor.offset > scopeStart && state.cursor.offset <= scopeEnd {
+		before := state.original[scopeStart:state.cursor.offset]
+		if idx := strings.LastIndex(before, searchText); idx >= 0 {
+			offset := scopeStart + idx
+			return cursor{
+				offset:    offset,
+				endOffset: offset + len(searchText),
+				isReplace: true,
+			}, nil
+		}
 	}
 
 	searchIn := state.original[scopeStart:scopeEnd]

--- a/instrument/patch/apply_test.go
+++ b/instrument/patch/apply_test.go
@@ -398,6 +398,76 @@ replace time.runtimeSleep
 	}
 }
 
+// TestApplyPatch_DeferRacegostartAnchorsOnRacegostart mirrors
+// xgo_proc_defer_racegostart: match racegostart first, then replace the
+// preceding if raceenabled — not an earlier decoy if raceenabled in newproc1.
+func TestApplyPatch_DeferRacegostartAnchorsOnRacegostart(t *testing.T) {
+	source := `package runtime
+
+func newproc1(fn *funcval, callergp *g, callerpc uintptr) *g {
+	if raceenabled {
+		// decoy: unrelated earlier raceenabled block (must stay enabled)
+		racereadpc(nil, 0, 0)
+	}
+	// Set up race context.
+	if raceenabled {
+		newg.racectx = racegostart(callerpc)
+		newg.raceignore = 0
+	}
+	return newg
+}
+`
+
+	patch := `<patch xgo_proc_defer_racegostart>
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
+</patch>`
+
+	result, err := ApplyXgoPatchContent(source, patch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decoy block must remain raceenabled.
+	if !strings.Contains(result, "if raceenabled {\n\t\t// decoy") {
+		t.Fatalf("expected decoy if raceenabled preserved:\n%s", result)
+	}
+	// Race-context block must be disabled.
+	if !strings.Contains(result, "if false { // xgo: race setup moved after create callback (#341)") {
+		t.Fatalf("expected race-context if disabled:\n%s", result)
+	}
+	// Only one if false replacement.
+	if strings.Count(result, "if false { // xgo:") != 1 {
+		t.Fatalf("expected exactly one if false replacement:\n%s", result)
+	}
+}
+
+func TestApplyPatch_DeferRacegostartRequiresRacegostart(t *testing.T) {
+	source := `package runtime
+
+func newproc1() *g {
+	if raceenabled {
+		racereadpc(nil, 0, 0)
+	}
+	return nil
+}
+`
+
+	patch := `<patch xgo_proc_defer_racegostart>
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo
+</patch>`
+
+	_, err := ApplyXgoPatchContent(source, patch)
+	if err == nil {
+		t.Fatal("expected error when racegostart is missing from newproc1")
+	}
+}
+
 func TestApplyPatch_ReplaceWithoutFindError(t *testing.T) {
 	source := "package p"
 

--- a/patches/go1.24/src/runtime/proc.go.xgo.patch
+++ b/patches/go1.24/src/runtime/proc.go.xgo.patch
@@ -9,13 +9,26 @@ insert_before __xgo_curg := gp.m.curg;var __xgo_newg *g;
 </patch>
 
 <patch add_go_newproc_callback_v2>
-# Description: Add __xgo_callback_on_create_g call after newproc1 creates a goroutine.
-# Wraps the newproc1 call to save newg and invoke the callback.
-# Replaces: newg := newproc1(fn, gp, pc, false, waitReasonZero)
-# With extra wrapping that saves __xgo_newg and calls the create callback.
+# Description: Add __xgo_callback_on_create_g after newproc1, then set up race
+# context, then continue scheduling. Race setup must run AFTER the create
+# callback so parent writes to child __xgo_g happen-before racegostart
+# (issues #341 / #330). Callback stays off systemstack.
 goto func newproc
 	match waitReasonZero)
-	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;
+	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };
+</patch>
+
+<patch xgo_proc_defer_racegostart>
+# Description: Skip racegostart inside newproc1; it is re-run in newproc after
+# the xgo create callback so inherit writes are ordered before the race
+# detector's go happens-before edge.
+# Anchor on racegostart, then replace the last preceding if raceenabled
+# (decoy-safe). Stronger than the legacy live SequenceOffset path in
+# instrument_runtime/proc.go.
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
 </patch>
 
 <patch add_go_exit1_callback>

--- a/patches/go1.24/src/runtime/xgo_trap.go
+++ b/patches/go1.24/src/runtime/xgo_trap.go
@@ -238,15 +238,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/patches/go1.25/src/runtime/proc.go.xgo.patch
+++ b/patches/go1.25/src/runtime/proc.go.xgo.patch
@@ -12,13 +12,27 @@ newline
 </patch>
 
 <patch xgo_proc_newproc_callback>
-# Description: Add __xgo_callback_on_create_g call after newproc1 creates a goroutine.
-# Wraps the newproc1 call to save newg and invoke the callback.
-# Replaces: newg := newproc1(fn, gp, pc, false, waitReasonZero)
-# With extra wrapping that saves __xgo_newg and calls the create callback.
+# Description: Add __xgo_callback_on_create_g after newproc1, then set up race
+# context, then continue scheduling. Race setup must run AFTER the create
+# callback so parent writes to child __xgo_g happen-before racegostart
+# (issues #341 / #330). Callback stays off systemstack.
+# Wraps: newg := newproc1(fn, gp, pc, false, waitReasonZero)
 goto func newproc
 	match waitReasonZero)
-	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;
+	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };
+</patch>
+
+<patch xgo_proc_defer_racegostart>
+# Description: Skip racegostart inside newproc1; it is re-run in newproc after
+# the xgo create callback so inherit writes are ordered before the race
+# detector's go happens-before edge.
+# Anchor on racegostart, then replace the last preceding if raceenabled
+# (decoy-safe). Stronger than the legacy live SequenceOffset path in
+# instrument_runtime/proc.go.
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
 </patch>
 
 <patch xgo_proc_goexit1>

--- a/patches/go1.25/src/runtime/xgo_trap.go
+++ b/patches/go1.25/src/runtime/xgo_trap.go
@@ -238,15 +238,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/patches/go1.26/src/runtime/proc.go.xgo.patch
+++ b/patches/go1.26/src/runtime/proc.go.xgo.patch
@@ -12,13 +12,27 @@ newline
 </patch>
 
 <patch xgo_proc_newproc_callback>
-# Description: Add __xgo_callback_on_create_g call after newproc1 creates a goroutine.
-# Wraps the newproc1 call to save newg and invoke the callback.
-# Replaces: newg := newproc1(fn, gp, pc, false, waitReasonZero)
-# With extra wrapping that saves __xgo_newg and calls the create callback.
+# Description: Add __xgo_callback_on_create_g after newproc1, then set up race
+# context, then continue scheduling. Race setup must run AFTER the create
+# callback so parent writes to child __xgo_g happen-before racegostart
+# (issues #341 / #330). Callback stays off systemstack.
+# Wraps: newg := newproc1(fn, gp, pc, false, waitReasonZero)
 goto func newproc
 	match waitReasonZero)
-	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;
+	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };
+</patch>
+
+<patch xgo_proc_defer_racegostart>
+# Description: Skip racegostart inside newproc1; it is re-run in newproc after
+# the xgo create callback so inherit writes are ordered before the race
+# detector's go happens-before edge.
+# Anchor on racegostart, then replace the last preceding if raceenabled
+# (decoy-safe). Stronger than the legacy live SequenceOffset path in
+# instrument_runtime/proc.go.
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
 </patch>
 
 <patch xgo_proc_goexit1>

--- a/patches/go1.26/src/runtime/xgo_trap.go
+++ b/patches/go1.26/src/runtime/xgo_trap.go
@@ -238,15 +238,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/patches/go1.27/src/runtime/proc.go.xgo.patch
+++ b/patches/go1.27/src/runtime/proc.go.xgo.patch
@@ -12,13 +12,27 @@ newline
 </patch>
 
 <patch xgo_proc_newproc_callback>
-# Description: Add __xgo_callback_on_create_g call after newproc1 creates a goroutine.
-# Wraps the newproc1 call to save newg and invoke the callback.
-# Replaces: newg := newproc1(fn, gp, pc, false, waitReasonZero)
-# With extra wrapping that saves __xgo_newg and calls the create callback.
+# Description: Add __xgo_callback_on_create_g after newproc1, then set up race
+# context, then continue scheduling. Race setup must run AFTER the create
+# callback so parent writes to child __xgo_g happen-before racegostart
+# (issues #341 / #330). Callback stays off systemstack.
+# Wraps: newg := newproc1(fn, gp, pc, false, waitReasonZero)
 goto func newproc
 	match waitReasonZero)
-	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;
+	insert_after ;__xgo_newg=newg});__xgo_callback_on_create_g(__xgo_curg,__xgo_newg);systemstack(func(){newg:=__xgo_newg;if raceenabled { newg.racectx = racegostart(pc); newg.raceignore = 0; if newg.labels != nil { racereleasemergeg(newg, unsafe.Pointer(&labelSync)) }; };
+</patch>
+
+<patch xgo_proc_defer_racegostart>
+# Description: Skip racegostart inside newproc1; it is re-run in newproc after
+# the xgo create callback so inherit writes are ordered before the race
+# detector's go happens-before edge.
+# Anchor on racegostart, then replace the last preceding if raceenabled
+# (decoy-safe). Stronger than the legacy live SequenceOffset path in
+# instrument_runtime/proc.go.
+goto func newproc1
+match racegostart(
+find_for_replace if raceenabled {
+replace if false { // xgo: race setup moved after create callback (#341)
 </patch>
 
 <patch xgo_proc_goexit1>

--- a/patches/go1.27/src/runtime/xgo_trap.go
+++ b/patches/go1.27/src/runtime/xgo_trap.go
@@ -238,15 +238,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/runtime/internal/runtime/xgo_trap_template.go
+++ b/runtime/internal/runtime/xgo_trap_template.go
@@ -239,15 +239,30 @@ func __xgo_callback_on_exit_g() {
 	for _, callback := range __xgo_on_exit_g_callbacks {
 		callback()
 	}
+	// Publish happens-before for __xgo_g before this g is freelisted and
+	// reused. Custom fields on g are not covered by the runtime freelist's
+	// race annotations; without release/acquire, exit vs reuse races (#341).
+	curg := getg().m.curg
+	if curg == nil {
+		return
+	}
+	// Clear residual state before release so the zero write is published
+	// to the create-side raceacquire (freelist reuse under -race; #341).
+	curg.__xgo_g = __xgo_g{}
+	if raceenabled {
+		racerelease(unsafe.Pointer(&curg.__xgo_g))
+	}
 }
 
 func __xgo_callback_on_create_g(curg *g, newg *g) {
 	if newg == nil {
 		return
 	}
-	// newg might be reused from an already exited goroutine
-	// so here we need to explicitly clear the __xgo_g
-	// clear
+	// Acquire happens-before from the previous owner of this g slot (see
+	// __xgo_callback_on_exit_g), then clear residual state from freelist reuse.
+	if raceenabled {
+		raceacquire(unsafe.Pointer(&newg.__xgo_g))
+	}
 	newg.__xgo_g = __xgo_g{}
 	if len(__xgo_on_create_g_callbacks) == 0 {
 		return

--- a/runtime/internal/stack/export.go
+++ b/runtime/internal/stack/export.go
@@ -13,10 +13,13 @@ func Export(stack *Stack, offsetNS int64) *stack_model.Stack {
 	if stack == nil {
 		return nil
 	}
+	// Snapshot under the stack mutex so concurrent Push/Finish cannot race
+	// with the export walk (Phase 1 race fix).
+	begin, _, roots := stack.Snapshot()
 	return &stack_model.Stack{
 		Format:   "stack",
-		Begin:    stack.Begin.Format(time.RFC3339),
-		Children: ExportStackEntries(stack.Roots, stack.Begin, offsetNS),
+		Begin:    begin.Format(time.RFC3339),
+		Children: ExportStackEntries(roots, begin, offsetNS),
 	}
 }
 
@@ -39,23 +42,26 @@ func ExportStackEntry(entry *Entry, rootBegin time.Time, offsetNS int64) *stack_
 	var isRunning bool
 	children := ExportStackEntries(entry.Children, rootBegin, offsetNS)
 	beginNs := entry.BeginNs + offsetNS
-	// stackEndNs := entry.EndNs
 	endNs := entry.EndNs + offsetNS
 	fnInfo := ExportFuncInfo(entry)
 	if entry.Go && entry.GetStack != nil {
 		if !flags.XGO_RACE_SAFE {
-			// handle async stack
-			stack := entry.GetStack()
-			if stack != nil {
-				// NOTE: this might be unsafe since the
-				// child goroutine might be running
-				exportedStack := Export(stack, beginNs)
-				children = append(children, exportedStack.Children...)
-				if stack.End.IsZero() {
+			// Child stack is snapshotted under its own mutex inside Export /
+			// Snapshot — safe if the child is still running.
+			childStack := entry.GetStack()
+			if childStack != nil {
+				childBegin, childEnd, childRoots := childStack.Snapshot()
+				exportedChildren := ExportStackEntries(childRoots, childBegin, beginNs)
+				children = append(children, exportedChildren...)
+				// Prefer zero-value compare over IsZero(): time.Time methods can
+				// be instrumented under --trap-stdlib / --trap-all and re-enter
+				// trap/export (see SetEndIfZero). Safe outside mu, but keep
+				// export free of instrumentable time methods.
+				if childEnd == (time.Time{}) {
 					isRunning = true
-					endNs = runtime.XgoRealTimeNow().UnixNano() - stack.Begin.UnixNano() + beginNs
+					endNs = runtime.XgoRealTimeNow().UnixNano() - childBegin.UnixNano() + beginNs
 				} else {
-					endNs = stack.End.UnixNano() - stack.Begin.UnixNano() + beginNs
+					endNs = childEnd.UnixNano() - childBegin.UnixNano() + beginNs
 				}
 			}
 		} else {

--- a/runtime/internal/stack/stack.go
+++ b/runtime/internal/stack/stack.go
@@ -1,12 +1,23 @@
 package stack
 
 import (
+	"sync"
 	"time"
 
 	"github.com/xhd2015/xgo/runtime/core"
 )
 
+// Stack is a per-goroutine call tree. All tree mutations and export snapshots
+// go through mu so concurrent Push (child) vs Export (parent) is race-free
+// under -race (see race_export / issue #341 follow-up Phase 1).
+//
+// IMPORTANT: never call instrumented functions (e.g. time.Time methods that
+// may trap) while holding mu — trap re-enters GetData and deadlocks.
 type Stack struct {
+	mu sync.Mutex
+
+	// Begin is fixed after stack creation; safe to read without mu for
+	// computing relative nanoseconds outside the lock.
 	Begin      time.Time
 	End        time.Time
 	MaxEntryID int
@@ -73,6 +84,14 @@ func Detach() {
 
 // push returns the old top
 func (c *Stack) Push(cur *Entry) *Entry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pushLocked(cur)
+}
+
+func (c *Stack) pushLocked(cur *Entry) *Entry {
+	// Historical behavior: Push bumps MaxEntryID even though Entry.ID was
+	// already assigned in NewEntry.
 	c.MaxEntryID++
 	oldTop := c.Top
 	if oldTop == nil {
@@ -86,13 +105,96 @@ func (c *Stack) Push(cur *Entry) *Entry {
 }
 
 func (c *Stack) NewEntry(begin time.Time, fnName string) *Entry {
+	// Compute relative time outside the lock (time methods may trap).
+	beginNs := begin.UnixNano() - c.Begin.UnixNano()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.newEntryLocked(beginNs, fnName)
+}
+
+func (c *Stack) newEntryLocked(beginNs int64, fnName string) *Entry {
 	c.MaxEntryID++
-	cur := &Entry{
+	return &Entry{
 		ID:       c.MaxEntryID,
 		FuncName: fnName,
-		BeginNs:  begin.UnixNano() - c.Begin.UnixNano(),
+		BeginNs:  beginNs,
 	}
-	return cur
+}
+
+// PushNew creates an entry, pushes it, runs setup, and increments Depth under
+// one lock so the tree is never observed half-updated by Export.
+// MaxEntryID is bumped twice (newEntry + push), matching historical NewEntry+Push.
+func (c *Stack) PushNew(begin time.Time, fnName string, setup func(*Entry)) (cur *Entry, oldTop *Entry) {
+	beginNs := begin.UnixNano() - c.Begin.UnixNano()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cur = c.newEntryLocked(beginNs, fnName)
+	oldTop = c.pushLocked(cur)
+	if setup != nil {
+		setup(cur)
+	}
+	c.Depth++
+	return cur, oldTop
+}
+
+// Finish completes an entry, restores Top, decrements Depth under lock.
+// finish must not call instrumented functions (no time.Time methods, no traps).
+func (c *Stack) Finish(cur *Entry, oldTop *Entry, end time.Time, setStackEnd bool, finish func(*Entry)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if setStackEnd {
+		c.End = end
+	}
+	if finish != nil {
+		finish(cur)
+	}
+	c.Top = oldTop
+	c.Depth--
+}
+
+// AppendGoChild attaches a synthetic "go" node under the current Top under lock.
+func (c *Stack) AppendGoChild(beginNs int64, getStack func() *Stack) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Top == nil {
+		return
+	}
+	child := &Entry{
+		BeginNs:  beginNs,
+		Go:       true,
+		FuncName: "go",
+		GetStack: getStack,
+	}
+	c.Top.Children = append(c.Top.Children, child)
+}
+
+// SetEndIfZero records stack end time once (goroutine exit).
+func (c *Stack) SetEndIfZero(t time.Time) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Do not call time.Time methods (e.g. IsZero) while holding mu — they are
+	// instrumented and re-enter trap → GetData → same mutex (deadlock).
+	if c.End == (time.Time{}) {
+		c.End = t
+	}
+}
+
+// Snapshot copies the tree for race-free export. GetStack funcs still point at
+// the live Stack; callers Export those under their own locks.
+// Must not invoke instrumented code while holding mu.
+func (c *Stack) Snapshot() (begin, end time.Time, roots []*Entry) {
+	if c == nil {
+		return time.Time{}, time.Time{}, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.Begin, c.End, cloneEntries(c.Roots)
 }
 
 type Field struct {
@@ -114,12 +216,42 @@ func (s *Entry) GetData(key interface{}) interface{} {
 type StackArgs []interface{}
 
 func (c *Stack) GetData(key interface{}) interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.Data[key]
 }
 
 func (c *Stack) SetData(key, value interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.Data == nil {
 		c.Data = make(map[interface{}]interface{}, 1)
 	}
 	c.Data[key] = value
+}
+
+func cloneEntries(entries []*Entry) []*Entry {
+	if entries == nil {
+		return nil
+	}
+	out := make([]*Entry, len(entries))
+	for i, e := range entries {
+		out[i] = cloneEntry(e)
+	}
+	return out
+}
+
+func cloneEntry(e *Entry) *Entry {
+	if e == nil {
+		return nil
+	}
+	cp := *e
+	cp.Children = cloneEntries(e.Children)
+	if e.Data != nil {
+		cp.Data = make(EntryData, len(e.Data))
+		for k, v := range e.Data {
+			cp.Data[k] = v
+		}
+	}
+	return &cp
 }

--- a/runtime/internal/trap/init.go
+++ b/runtime/internal/trap/init.go
@@ -17,14 +17,12 @@ func init() {
 	})
 	runtime.XgoOnExitG(func() {
 		g := stack.GetG()
-		stack := g.GetStack()
-		if stack == nil {
+		stk := g.GetStack()
+		if stk == nil {
 			return
 		}
-		if stack.End.IsZero() {
-			// fill end
-			stack.End = runtime.XgoRealTimeNow()
-		}
+		// fill end under stack mutex (export may snapshot concurrently)
+		stk.SetEndIfZero(runtime.XgoRealTimeNow())
 	})
 }
 
@@ -64,17 +62,10 @@ func inerhitStack(curG stack.G, newG stack.G) {
 		newStackData.hasStartedTracing = true
 		newStackData.filterTrace = stackData.filterTrace
 
-		if curStack.Top != nil {
-			child := &stack.Entry{
-				BeginNs:  newStack.Begin.Sub(curStack.Begin).Nanoseconds(),
-				Go:       true,
-				FuncName: "go",
-				GetStack: func() *stack.Stack {
-					return newStack
-				},
-			}
-			curStack.Top.Children = append(curStack.Top.Children, child)
-		}
+		// Append under parent stack mutex so Export cannot race with Push/Top.
+		curStack.AppendGoChild(newStack.Begin.Sub(curStack.Begin).Nanoseconds(), func() *stack.Stack {
+			return newStack
+		})
 	}
 }
 

--- a/runtime/internal/trap/trap.go
+++ b/runtime/internal/trap/trap.go
@@ -255,12 +255,7 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 	//
 	//
 	// === tracing records ===
-	file, line := runtimeFuncInfo.FileLine(pc)
-	cur := stk.NewEntry(begin, name)
-	oldTop := stk.Push(cur)
-	cur.File = file
-	cur.Line = line
-	cur.FuncInfo = funcInfo
+	callFile, callLine := runtimeFuncInfo.FileLine(pc)
 
 	if isStartTracing && !isTesting {
 		var onFinish func(stack stack_model.IStack)
@@ -281,9 +276,8 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 			if rvalue.IsValid() && rvalue.Kind() == reflect.Struct {
 				outputFileField := rvalue.FieldByName("OutputFile")
 				if outputFileField.IsValid() {
-					file, ok := outputFileField.Interface().(string)
-					if ok {
-						outputFile = file
+					if f, ok := outputFileField.Interface().(string); ok {
+						outputFile = f
 					}
 				}
 				onFinishField := rvalue.FieldByName("OnFinish")
@@ -325,8 +319,15 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 		copy(marshalNames[1:], argNamesNoCtx)
 		copy(marshalArgs[1:], argsNoCtx)
 	}
-	cur.Args = json.RawMessage(xgo_runtime.MarshalNoError(newStructValue(marshalNames, marshalArgs)))
-	stk.Depth++
+	argsJSON := json.RawMessage(xgo_runtime.MarshalNoError(newStructValue(marshalNames, marshalArgs)))
+
+	// Push under stack mutex so Export cannot observe a half-built entry.
+	cur, oldTop := stk.PushNew(begin, name, func(cur *stack.Entry) {
+		cur.File = callFile
+		cur.Line = callLine
+		cur.FuncInfo = funcInfo
+		cur.Args = argsJSON
+	})
 
 	var hitMock bool
 	post := func() {
@@ -343,16 +344,15 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 		// see https://github.com/xhd2015/xgo/issues/307
 		// so we add a standalone flag `Finished`
 		end := xgo_runtime.XgoRealTimeNow()
-		if isStartTracing {
-			stk.End = end
-		}
-		cur.EndNs = end.UnixNano() - stk.Begin.UnixNano()
-		cur.Finished = true
-		cur.HitMock = hitMock
+
+		// Compute post fields outside the lock when possible; panic line needs
+		// runtime.Callers which must not run while holding stack.mu if export
+		// also takes locks in other orders (export only locks stacks).
 		var hasPanic bool
+		var panicLine int
+		var errStr string
 		if pe, retpc := xgo_runtime.XgoPeekPanic(); pe != nil {
 			hasPanic = true
-			cur.Panic = true
 			// frame:
 			//   0: trap.trap
 			//   1: runtime.gopanic
@@ -389,21 +389,35 @@ func trap(infoPtr unsafe.Pointer, recvPtr interface{}, args []interface{}, resul
 				entryPC := runtime.FuncForPC(pc).Entry()
 				if entryPC == retEntryPC {
 					frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
-					cur.PanicLine = frame.Line
+					panicLine = frame.Line
 					break
 				}
 			}
-			cur.Error = fmt.Sprint(pe)
+			errStr = fmt.Sprint(pe)
 		}
 
 		resultNamesNoErr, resultsNoErr, resErr := trySplitLastError(resultNames, results)
-		cur.Results = json.RawMessage(xgo_runtime.MarshalNoError(newStructValue(resultNamesNoErr, resultsNoErr)))
+		resultsJSON := json.RawMessage(xgo_runtime.MarshalNoError(newStructValue(resultNamesNoErr, resultsNoErr)))
 		if !hasPanic && resErr != nil {
-			cur.Error = resErr.Error()
+			errStr = resErr.Error()
 		}
 
-		stk.Top = oldTop
-		stk.Depth--
+		// Relative end time outside lock (time methods may trap / deadlock).
+		endNs := end.UnixNano() - stk.Begin.UnixNano()
+		// finish under lock: entry fields + Top/Depth for race-free export
+		stk.Finish(cur, oldTop, end, isStartTracing, func(cur *stack.Entry) {
+			cur.EndNs = endNs
+			cur.Finished = true
+			cur.HitMock = hitMock
+			if hasPanic {
+				cur.Panic = true
+				cur.PanicLine = panicLine
+			}
+			cur.Results = resultsJSON
+			if errStr != "" {
+				cur.Error = errStr
+			}
+		})
 		if isStartTracing {
 			exportedStack := stack.Export(stk, 0)
 			if isTesting {

--- a/runtime/internal/trap/var.go
+++ b/runtime/internal/trap/var.go
@@ -148,12 +148,18 @@ func doTrapVar(funcInfo *core.FuncInfo, stk *stack.Stack, begin time.Time, traci
 		return
 	}
 	_, file, line, _ := runtime.Caller(SKIP + 2)
-	cur := stk.NewEntry(begin, funcInfo.Name)
-	cur.File = file
-	cur.Line = line
-	cur.FuncInfo = funcInfo
-	cur.Results = json.RawMessage(xgo_runtime.MarshalNoError(res))
-	stk.Top = stk.Push(cur)
-	cur.EndNs = xgo_runtime.XgoRealTimeNow().UnixNano() - stk.Begin.UnixNano()
-	cur.Finished = true
+	end := xgo_runtime.XgoRealTimeNow()
+	endNs := end.UnixNano() - stk.Begin.UnixNano()
+	resultsJSON := json.RawMessage(xgo_runtime.MarshalNoError(res))
+	// Single locked push+finish so export cannot race with var trap records.
+	cur, oldTop := stk.PushNew(begin, funcInfo.Name, func(cur *stack.Entry) {
+		cur.File = file
+		cur.Line = line
+		cur.FuncInfo = funcInfo
+		cur.Results = resultsJSON
+	})
+	stk.Finish(cur, oldTop, end, false, func(cur *stack.Entry) {
+		cur.EndNs = endNs
+		cur.Finished = true
+	})
 }

--- a/runtime/test/tls/race_inherit/go.mod
+++ b/runtime/test/tls/race_inherit/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/tls/race_inherit
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../..

--- a/runtime/test/tls/race_inherit/race_inherit.go
+++ b/runtime/test/tls/race_inherit/race_inherit.go
@@ -1,0 +1,1 @@
+package race_inherit

--- a/runtime/test/tls/race_inherit/race_inherit_test.go
+++ b/runtime/test/tls/race_inherit/race_inherit_test.go
@@ -1,0 +1,78 @@
+package race_inherit_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/tls"
+)
+
+var inheritKey = tls.DeclareInherit("race_inherit_key")
+var noInheritKey = tls.Declare("race_no_inherit_key")
+
+// TestTLSInheritAcrossGoNoRace is a green canary under -race (no --xgo-race-safe).
+//
+// What it guards:
+//   - TLS inherit into child goroutines must remain correct under -race.
+//   - Freelist reuse of *g / __xgo_g must not trip the race detector
+//     (exit/create use racerelease/raceacquire on __xgo_g; see #341).
+//
+// Multi-round nested go churns the g freelist so residual __xgo_g state is
+// exercised across owners. This test is expected to PASS; it is not a
+// RED-first fixture for clear-vs-release ordering.
+//
+// If this ever fails with DATA RACE on __xgo_g / G / TLS paths, review:
+//  1. __xgo_callback_on_exit_g: racerelease present; clear of __xgo_g should
+//     happen-before that release (or only clear after raceacquire on create).
+//  2. __xgo_callback_on_create_g: raceacquire then clear residual, then inherit.
+//  3. racegostart runs after the create callback (parent inherit writes HB).
+//  4. All mirrored trap copies (patches/assets/runtime_gen) stay in sync.
+func TestTLSInheritAcrossGoNoRace(t *testing.T) {
+	const rounds = 20
+	const n = 32
+	for r := 0; r < rounds; r++ {
+		inheritKey.Set(42 + r)
+		noInheritKey.Set(7)
+		var wg sync.WaitGroup
+		errs := make(chan string, n*2)
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func(want int) {
+				defer wg.Done()
+				// nested go to churn freelist + inherit chain
+				var inner sync.WaitGroup
+				inner.Add(1)
+				go func() {
+					defer inner.Done()
+					v, ok := inheritKey.GetOK()
+					if !ok {
+						errs <- "missing nested inherit"
+						return
+					}
+					if v.(int) != want {
+						errs <- "bad nested inherit"
+					}
+				}()
+				v, ok := inheritKey.GetOK()
+				if !ok {
+					errs <- "missing inherit"
+					return
+				}
+				if v.(int) != want {
+					errs <- "bad inherit value"
+				}
+				if _, ok := noInheritKey.GetOK(); ok {
+					errs <- "non-inherit leaked"
+				}
+				inner.Wait()
+			}(42 + r)
+		}
+		// parent mutates while children still running
+		inheritKey.Set(42 + r)
+		wg.Wait()
+		close(errs)
+		for e := range errs {
+			t.Error(e)
+		}
+	}
+}

--- a/runtime/test/tls/race_inherit/test-config.txt
+++ b/runtime/test/tls/race_inherit/test-config.txt
@@ -1,0 +1,5 @@
+# Green canary: TLS inherit + g freelist reuse of __xgo_g under -race.
+# WITHOUT --xgo-race-safe so inheritance stays enabled.
+# Expected PASS. If DATA RACE appears, review exit/create racerelease/raceacquire
+# (and clear vs release order) on __xgo_g — see race_inherit_test.go comments.
+flags: -race

--- a/runtime/test/tls/race_inherit_trap_all/go.mod
+++ b/runtime/test/tls/race_inherit_trap_all/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/tls/race_inherit_trap_all
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../..

--- a/runtime/test/tls/race_inherit_trap_all/race_inherit_trap_all.go
+++ b/runtime/test/tls/race_inherit_trap_all/race_inherit_trap_all.go
@@ -1,0 +1,1 @@
+package race_inherit_trap_all

--- a/runtime/test/tls/race_inherit_trap_all/race_inherit_trap_all_test.go
+++ b/runtime/test/tls/race_inherit_trap_all/race_inherit_trap_all_test.go
@@ -1,0 +1,69 @@
+package race_inherit_trap_all_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/tls"
+)
+
+var inheritKey = tls.DeclareInherit("race_inherit_key")
+var noInheritKey = tls.Declare("race_no_inherit_key")
+
+// TestTLSInheritAcrossGoNoRace_trap_all is a green canary under
+// -race --trap-all (no --xgo-race-safe).
+//
+// Same TLS inherit / freelist guards as race_inherit, plus trap-all
+// re-entrancy during create-g inherit.
+//
+// Expected PASS. If DATA RACE or hang appears, review exit/create
+// racerelease/raceacquire and racegostart-after-callback ordering.
+func TestTLSInheritAcrossGoNoRace_trap_all(t *testing.T) {
+	const rounds = 20
+	const n = 32
+	for r := 0; r < rounds; r++ {
+		inheritKey.Set(42 + r)
+		noInheritKey.Set(7)
+		var wg sync.WaitGroup
+		errs := make(chan string, n*2)
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func(want int) {
+				defer wg.Done()
+				// nested go to churn freelist + inherit chain
+				var inner sync.WaitGroup
+				inner.Add(1)
+				go func() {
+					defer inner.Done()
+					v, ok := inheritKey.GetOK()
+					if !ok {
+						errs <- "missing nested inherit"
+						return
+					}
+					if v.(int) != want {
+						errs <- "bad nested inherit"
+					}
+				}()
+				v, ok := inheritKey.GetOK()
+				if !ok {
+					errs <- "missing inherit"
+					return
+				}
+				if v.(int) != want {
+					errs <- "bad inherit value"
+				}
+				if _, ok := noInheritKey.GetOK(); ok {
+					errs <- "non-inherit leaked"
+				}
+				inner.Wait()
+			}(42 + r)
+		}
+		// parent mutates while children still running
+		inheritKey.Set(42 + r)
+		wg.Wait()
+		close(errs)
+		for e := range errs {
+			t.Error(e)
+		}
+	}
+}

--- a/runtime/test/tls/race_inherit_trap_all/test-config.txt
+++ b/runtime/test/tls/race_inherit_trap_all/test-config.txt
@@ -1,0 +1,3 @@
+# Green canary: TLS inherit + freelist reuse under -race --trap-all.
+# WITHOUT --xgo-race-safe. Expected PASS.
+flags: -race --trap-all

--- a/runtime/test/tls/race_inherit_trap_stdlib/go.mod
+++ b/runtime/test/tls/race_inherit_trap_stdlib/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/tls/race_inherit_trap_stdlib
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../..

--- a/runtime/test/tls/race_inherit_trap_stdlib/race_inherit_trap_stdlib.go
+++ b/runtime/test/tls/race_inherit_trap_stdlib/race_inherit_trap_stdlib.go
@@ -1,0 +1,1 @@
+package race_inherit_trap_stdlib

--- a/runtime/test/tls/race_inherit_trap_stdlib/race_inherit_trap_stdlib_test.go
+++ b/runtime/test/tls/race_inherit_trap_stdlib/race_inherit_trap_stdlib_test.go
@@ -1,0 +1,69 @@
+package race_inherit_trap_stdlib_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/tls"
+)
+
+var inheritKey = tls.DeclareInherit("race_inherit_key")
+var noInheritKey = tls.Declare("race_no_inherit_key")
+
+// TestTLSInheritAcrossGoNoRace_trap_stdlib is a green canary under
+// -race --trap-stdlib (no --xgo-race-safe).
+//
+// Same TLS inherit / freelist guards as race_inherit, plus stdlib trap
+// pressure during create-g inherit.
+//
+// Expected PASS. If DATA RACE or hang appears, review exit/create
+// racerelease/raceacquire and racegostart-after-callback ordering.
+func TestTLSInheritAcrossGoNoRace_trap_stdlib(t *testing.T) {
+	const rounds = 20
+	const n = 32
+	for r := 0; r < rounds; r++ {
+		inheritKey.Set(42 + r)
+		noInheritKey.Set(7)
+		var wg sync.WaitGroup
+		errs := make(chan string, n*2)
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func(want int) {
+				defer wg.Done()
+				// nested go to churn freelist + inherit chain
+				var inner sync.WaitGroup
+				inner.Add(1)
+				go func() {
+					defer inner.Done()
+					v, ok := inheritKey.GetOK()
+					if !ok {
+						errs <- "missing nested inherit"
+						return
+					}
+					if v.(int) != want {
+						errs <- "bad nested inherit"
+					}
+				}()
+				v, ok := inheritKey.GetOK()
+				if !ok {
+					errs <- "missing inherit"
+					return
+				}
+				if v.(int) != want {
+					errs <- "bad inherit value"
+				}
+				if _, ok := noInheritKey.GetOK(); ok {
+					errs <- "non-inherit leaked"
+				}
+				inner.Wait()
+			}(42 + r)
+		}
+		// parent mutates while children still running
+		inheritKey.Set(42 + r)
+		wg.Wait()
+		close(errs)
+		for e := range errs {
+			t.Error(e)
+		}
+	}
+}

--- a/runtime/test/tls/race_inherit_trap_stdlib/test-config.txt
+++ b/runtime/test/tls/race_inherit_trap_stdlib/test-config.txt
@@ -1,0 +1,3 @@
+# Green canary: TLS inherit + freelist reuse under -race --trap-stdlib.
+# WITHOUT --xgo-race-safe. Expected PASS.
+flags: -race --trap-stdlib

--- a/runtime/test/trace/go_trace/race_export/go.mod
+++ b/runtime/test/trace/go_trace/race_export/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/trace/go_trace/race_export
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../../..

--- a/runtime/test/trace/go_trace/race_export/race_export.go
+++ b/runtime/test/trace/go_trace/race_export/race_export.go
@@ -1,0 +1,1 @@
+package race_export

--- a/runtime/test/trace/go_trace/race_export/race_export_test.go
+++ b/runtime/test/trace/go_trace/race_export/race_export_test.go
@@ -1,0 +1,66 @@
+package race_export_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xhd2015/xgo/runtime/trace"
+	"github.com/xhd2015/xgo/runtime/trace/stack_model"
+)
+
+func hello(s string) string {
+	return "hello " + s
+}
+
+func helloSlow(s string) string {
+	// Keep the child in trap/instrumented work while parent may export.
+	time.Sleep(30 * time.Millisecond)
+	return "hello " + s
+}
+
+// TestGoTraceExportAcrossGoNoRace is the RED fixture for remaining race class R1:
+// parent export/JSON of the stack tree races with child Stack.Push under -race
+// without --xgo-race-safe.
+//
+// Expected after Phase 1 fix: PASS with go child present and zero DATA RACE.
+func TestGoTraceExportAcrossGoNoRace(t *testing.T) {
+	var stack stack_model.IStack
+	var wg sync.WaitGroup
+	const n = 16
+
+	_, _ = trace.Trace(trace.Config{
+		OnFinish: func(s stack_model.IStack) {
+			stack = s
+		},
+	}, nil, func() (interface{}, error) {
+		hello("before")
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				helloSlow("world")
+			}()
+		}
+		// Do not wg.Wait() before Trace returns: OnFinish export must overlap
+		// with still-running children (R1 concurrency).
+		hello("after")
+		time.Sleep(5 * time.Millisecond)
+		return nil, nil
+	})
+
+	wg.Wait()
+
+	if stack == nil {
+		t.Fatal("stack is nil")
+	}
+	json, err := stack.JSON()
+	if err != nil {
+		t.Fatalf("stack JSON: %v", err)
+	}
+	// Name may be "go" or "go (running)".
+	if !strings.Contains(string(json), `"Name":"go`) {
+		t.Fatalf("expected go child in stack export, got:\n%s", json)
+	}
+}

--- a/runtime/test/trace/go_trace/race_export/test-config.txt
+++ b/runtime/test/trace/go_trace/race_export/test-config.txt
@@ -1,0 +1,4 @@
+# Race R1 regression: concurrent go-trace export vs child stack Push under -race.
+# Intentionally WITHOUT --xgo-race-safe (that mode hides async go export).
+# Phase 1: stack mutex + Snapshot export — must stay GREEN.
+flags: -race

--- a/runtime/test/trace/go_trace/race_export_trap_all/go.mod
+++ b/runtime/test/trace/go_trace/race_export_trap_all/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/trace/go_trace/race_export_trap_all
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../../..

--- a/runtime/test/trace/go_trace/race_export_trap_all/race_export_trap_all.go
+++ b/runtime/test/trace/go_trace/race_export_trap_all/race_export_trap_all.go
@@ -1,0 +1,1 @@
+package race_export_trap_all

--- a/runtime/test/trace/go_trace/race_export_trap_all/race_export_trap_all_test.go
+++ b/runtime/test/trace/go_trace/race_export_trap_all/race_export_trap_all_test.go
@@ -1,0 +1,70 @@
+package race_export_trap_all_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xhd2015/xgo/runtime/trace"
+	"github.com/xhd2015/xgo/runtime/trace/stack_model"
+)
+
+func hello(s string) string {
+	return "hello " + s
+}
+
+func helloSlow(s string) string {
+	// Keep the child in trap/instrumented work while parent may export.
+	time.Sleep(30 * time.Millisecond)
+	return "hello " + s
+}
+
+// TestGoTraceExportAcrossGoNoRace_trap_all is a green canary under
+// -race --trap-all (no --xgo-race-safe).
+//
+// What it guards beyond the plain -race race_export canary:
+//   - Concurrent export vs child Push while trap can re-enter (trap-all).
+//   - Export paths that still call instrumentable time methods
+//     (Format / UnixNano) must not hang or DATA RACE under full trap.
+//
+// Expected PASS with go child present and zero DATA RACE.
+func TestGoTraceExportAcrossGoNoRace_trap_all(t *testing.T) {
+	var stack stack_model.IStack
+	var wg sync.WaitGroup
+	const n = 16
+
+	_, _ = trace.Trace(trace.Config{
+		OnFinish: func(s stack_model.IStack) {
+			stack = s
+		},
+	}, nil, func() (interface{}, error) {
+		hello("before")
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				helloSlow("world")
+			}()
+		}
+		// Do not wg.Wait() before Trace returns: OnFinish export must overlap
+		// with still-running children (R1 concurrency).
+		hello("after")
+		time.Sleep(5 * time.Millisecond)
+		return nil, nil
+	})
+
+	wg.Wait()
+
+	if stack == nil {
+		t.Fatal("stack is nil")
+	}
+	json, err := stack.JSON()
+	if err != nil {
+		t.Fatalf("stack JSON: %v", err)
+	}
+	// Name may be "go" or "go (running)".
+	if !strings.Contains(string(json), `"Name":"go`) {
+		t.Fatalf("expected go child in stack export, got:\n%s", json)
+	}
+}

--- a/runtime/test/trace/go_trace/race_export_trap_all/test-config.txt
+++ b/runtime/test/trace/go_trace/race_export_trap_all/test-config.txt
@@ -1,0 +1,5 @@
+# Green canary: concurrent go-trace export vs child Push under -race --trap-all.
+# Covers re-entrancy of instrumentable time methods (Format/UnixNano) and
+# Stack.mu lock discipline under full trap (see stack/export.go comments).
+# WITHOUT --xgo-race-safe. Expected PASS.
+flags: -race --trap-all

--- a/runtime/test/trace/go_trace/race_export_trap_stdlib/go.mod
+++ b/runtime/test/trace/go_trace/race_export_trap_stdlib/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/trace/go_trace/race_export_trap_stdlib
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../../..

--- a/runtime/test/trace/go_trace/race_export_trap_stdlib/race_export_trap_stdlib.go
+++ b/runtime/test/trace/go_trace/race_export_trap_stdlib/race_export_trap_stdlib.go
@@ -1,0 +1,1 @@
+package race_export_trap_stdlib

--- a/runtime/test/trace/go_trace/race_export_trap_stdlib/race_export_trap_stdlib_test.go
+++ b/runtime/test/trace/go_trace/race_export_trap_stdlib/race_export_trap_stdlib_test.go
@@ -1,0 +1,69 @@
+package race_export_trap_stdlib_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xhd2015/xgo/runtime/trace"
+	"github.com/xhd2015/xgo/runtime/trace/stack_model"
+)
+
+func hello(s string) string {
+	return "hello " + s
+}
+
+func helloSlow(s string) string {
+	// Keep the child in trap/instrumented work while parent may export.
+	time.Sleep(30 * time.Millisecond)
+	return "hello " + s
+}
+
+// TestGoTraceExportAcrossGoNoRace_trap_stdlib is a green canary under
+// -race --trap-stdlib (no --xgo-race-safe).
+//
+// What it guards beyond the plain -race race_export canary:
+//   - Concurrent export vs child Push with stdlib trapping enabled.
+//   - time.Time methods used during export remain safe under --trap-stdlib.
+//
+// Expected PASS with go child present and zero DATA RACE.
+func TestGoTraceExportAcrossGoNoRace_trap_stdlib(t *testing.T) {
+	var stack stack_model.IStack
+	var wg sync.WaitGroup
+	const n = 16
+
+	_, _ = trace.Trace(trace.Config{
+		OnFinish: func(s stack_model.IStack) {
+			stack = s
+		},
+	}, nil, func() (interface{}, error) {
+		hello("before")
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				helloSlow("world")
+			}()
+		}
+		// Do not wg.Wait() before Trace returns: OnFinish export must overlap
+		// with still-running children (R1 concurrency).
+		hello("after")
+		time.Sleep(5 * time.Millisecond)
+		return nil, nil
+	})
+
+	wg.Wait()
+
+	if stack == nil {
+		t.Fatal("stack is nil")
+	}
+	json, err := stack.JSON()
+	if err != nil {
+		t.Fatalf("stack JSON: %v", err)
+	}
+	// Name may be "go" or "go (running)".
+	if !strings.Contains(string(json), `"Name":"go`) {
+		t.Fatalf("expected go child in stack export, got:\n%s", json)
+	}
+}

--- a/runtime/test/trace/go_trace/race_export_trap_stdlib/test-config.txt
+++ b/runtime/test/trace/go_trace/race_export_trap_stdlib/test-config.txt
@@ -1,0 +1,4 @@
+# Green canary: concurrent go-trace export vs child Push under -race --trap-stdlib.
+# Stdlib-only trap pressure on time methods used during export.
+# WITHOUT --xgo-race-safe. Expected PASS.
+flags: -race --trap-stdlib

--- a/runtime/test/trace/go_trace/race_inherit/go.mod
+++ b/runtime/test/trace/go_trace/race_inherit/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/trace/go_trace/race_inherit
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../../..

--- a/runtime/test/trace/go_trace/race_inherit/race_inherit.go
+++ b/runtime/test/trace/go_trace/race_inherit/race_inherit.go
@@ -1,0 +1,1 @@
+package race_inherit

--- a/runtime/test/trace/go_trace/race_inherit/race_inherit_test.go
+++ b/runtime/test/trace/go_trace/race_inherit/race_inherit_test.go
@@ -1,0 +1,67 @@
+package race_inherit_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/mock"
+)
+
+func hello(s string) string {
+	return "hello " + s
+}
+
+// TestMockInheritAcrossGoNoRace is a green canary under -race (no --xgo-race-safe).
+//
+// What it guards (issue #341):
+//   - Mock state inherited into child goroutines must work under -race.
+//   - Create-g inherit must not race with the race detector's go edge
+//     (racegostart runs after __xgo_callback_on_create_g).
+//   - Freelist reuse of __xgo_g must not trip DATA RACE (exit/create
+//     racerelease/raceacquire; multi-round nested go churns freelist).
+//
+// Expected PASS. This is a regression guard, not a RED-first clear-order test.
+//
+// If this ever fails with DATA RACE on __xgo_g / mock inherit paths, review:
+//  1. racegostart after __xgo_callback_on_create_g (parent→child inherit HB).
+//  2. __xgo_callback_on_exit_g: racerelease; prefer clear of __xgo_g before release.
+//  3. __xgo_callback_on_create_g: raceacquire then clear residual, then inherit.
+//  4. Mirrored trap copies (patches/assets/runtime_gen) stay in sync.
+func TestMockInheritAcrossGoNoRace(t *testing.T) {
+	mock.Patch(hello, func(s string) string {
+		return "mocked " + s
+	})
+
+	const rounds = 20
+	const n = 32
+	for r := 0; r < rounds; r++ {
+		var wg sync.WaitGroup
+		errs := make(chan string, n*2)
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				// nested go: freelist churn + inherit chain (same shape as TLS canary)
+				var inner sync.WaitGroup
+				inner.Add(1)
+				go func() {
+					defer inner.Done()
+					got := hello("x")
+					if got != "mocked x" {
+						errs <- "nested: " + got
+					}
+				}()
+				got := hello("x")
+				if got != "mocked x" {
+					errs <- got
+				}
+				inner.Wait()
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for got := range errs {
+			t.Errorf("expect mock inherited into child goroutine, got %q", got)
+		}
+	}
+}

--- a/runtime/test/trace/go_trace/race_inherit/test-config.txt
+++ b/runtime/test/trace/go_trace/race_inherit/test-config.txt
@@ -1,0 +1,5 @@
+# Green canary: mock inherit + g freelist reuse of __xgo_g under -race (#341).
+# WITHOUT --xgo-race-safe so inheritance stays enabled.
+# Expected PASS. If DATA RACE appears, review create-g racegostart order and
+# exit/create racerelease/raceacquire on __xgo_g — see race_inherit_test.go.
+flags: -race

--- a/runtime/test/trace/go_trace/race_inherit_trap_all/go.mod
+++ b/runtime/test/trace/go_trace/race_inherit_trap_all/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/trace/go_trace/race_inherit_trap_all
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../../..

--- a/runtime/test/trace/go_trace/race_inherit_trap_all/race_inherit_trap_all.go
+++ b/runtime/test/trace/go_trace/race_inherit_trap_all/race_inherit_trap_all.go
@@ -1,0 +1,1 @@
+package race_inherit_trap_all

--- a/runtime/test/trace/go_trace/race_inherit_trap_all/race_inherit_trap_all_test.go
+++ b/runtime/test/trace/go_trace/race_inherit_trap_all/race_inherit_trap_all_test.go
@@ -1,0 +1,59 @@
+package race_inherit_trap_all_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/mock"
+)
+
+func hello(s string) string {
+	return "hello " + s
+}
+
+// TestMockInheritAcrossGoNoRace_trap_all is a green canary under
+// -race --trap-all (no --xgo-race-safe).
+//
+// Same inherit / freelist guards as race_inherit, plus trap-all re-entrancy
+// during create-g inherit (e.g. time methods used for beginNs deltas).
+//
+// Expected PASS. If DATA RACE or hang appears, review create-g racegostart
+// order, exit/create racerelease/raceacquire, and trap-all re-entry on inherit.
+func TestMockInheritAcrossGoNoRace_trap_all(t *testing.T) {
+	mock.Patch(hello, func(s string) string {
+		return "mocked " + s
+	})
+
+	const rounds = 20
+	const n = 32
+	for r := 0; r < rounds; r++ {
+		var wg sync.WaitGroup
+		errs := make(chan string, n*2)
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				// nested go: freelist churn + inherit chain (same shape as TLS canary)
+				var inner sync.WaitGroup
+				inner.Add(1)
+				go func() {
+					defer inner.Done()
+					got := hello("x")
+					if got != "mocked x" {
+						errs <- "nested: " + got
+					}
+				}()
+				got := hello("x")
+				if got != "mocked x" {
+					errs <- got
+				}
+				inner.Wait()
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for got := range errs {
+			t.Errorf("expect mock inherited into child goroutine, got %q", got)
+		}
+	}
+}

--- a/runtime/test/trace/go_trace/race_inherit_trap_all/test-config.txt
+++ b/runtime/test/trace/go_trace/race_inherit_trap_all/test-config.txt
@@ -1,0 +1,3 @@
+# Green canary: mock inherit + freelist reuse under -race --trap-all (#341).
+# WITHOUT --xgo-race-safe. Expected PASS.
+flags: -race --trap-all

--- a/runtime/test/trace/go_trace/race_inherit_trap_stdlib/go.mod
+++ b/runtime/test/trace/go_trace/race_inherit_trap_stdlib/go.mod
@@ -1,0 +1,7 @@
+module github.com/xhd2015/xgo/runtime/test/trace/go_trace/race_inherit_trap_stdlib
+
+go 1.18
+
+require github.com/xhd2015/xgo/runtime v0.0.0
+
+replace github.com/xhd2015/xgo/runtime => ../../../..

--- a/runtime/test/trace/go_trace/race_inherit_trap_stdlib/race_inherit_trap_stdlib.go
+++ b/runtime/test/trace/go_trace/race_inherit_trap_stdlib/race_inherit_trap_stdlib.go
@@ -1,0 +1,1 @@
+package race_inherit_trap_stdlib

--- a/runtime/test/trace/go_trace/race_inherit_trap_stdlib/race_inherit_trap_stdlib_test.go
+++ b/runtime/test/trace/go_trace/race_inherit_trap_stdlib/race_inherit_trap_stdlib_test.go
@@ -1,0 +1,59 @@
+package race_inherit_trap_stdlib_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/mock"
+)
+
+func hello(s string) string {
+	return "hello " + s
+}
+
+// TestMockInheritAcrossGoNoRace_trap_stdlib is a green canary under
+// -race --trap-stdlib (no --xgo-race-safe).
+//
+// Same inherit / freelist guards as race_inherit, plus stdlib trap pressure
+// during create-g inherit.
+//
+// Expected PASS. If DATA RACE or hang appears, review create-g racegostart
+// order and exit/create racerelease/raceacquire on __xgo_g.
+func TestMockInheritAcrossGoNoRace_trap_stdlib(t *testing.T) {
+	mock.Patch(hello, func(s string) string {
+		return "mocked " + s
+	})
+
+	const rounds = 20
+	const n = 32
+	for r := 0; r < rounds; r++ {
+		var wg sync.WaitGroup
+		errs := make(chan string, n*2)
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				defer wg.Done()
+				// nested go: freelist churn + inherit chain (same shape as TLS canary)
+				var inner sync.WaitGroup
+				inner.Add(1)
+				go func() {
+					defer inner.Done()
+					got := hello("x")
+					if got != "mocked x" {
+						errs <- "nested: " + got
+					}
+				}()
+				got := hello("x")
+				if got != "mocked x" {
+					errs <- got
+				}
+				inner.Wait()
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for got := range errs {
+			t.Errorf("expect mock inherited into child goroutine, got %q", got)
+		}
+	}
+}

--- a/runtime/test/trace/go_trace/race_inherit_trap_stdlib/test-config.txt
+++ b/runtime/test/trace/go_trace/race_inherit_trap_stdlib/test-config.txt
@@ -1,0 +1,3 @@
+# Green canary: mock inherit + freelist reuse under -race --trap-stdlib (#341).
+# WITHOUT --xgo-race-safe. Expected PASS.
+flags: -race --trap-stdlib


### PR DESCRIPTION
## Summary

- Defer `racegostart` until **after** `__xgo_callback_on_create_g` so parent writes to child `__xgo_g` (mock/trace inheritance) happen-before the race detector’s go edge.
- On g exit/create, publish `racerelease`/`raceacquire` on `__xgo_g` and clear state so freelist reuse of `*g` does not report false DATA RACEs (custom fields on `g` are not covered by freelist race annotations).
- Add integration test `runtime/test/trace/go_trace/race_inherit` (`-race`, no `--xgo-race-safe`) that exercises mock inheritance across many child goroutines.

### Related issues

- **Fixes** https://github.com/xhd2015/xgo/issues/341 — DATA RACE when starting a goroutine with `-race` (inherit-on-create path).
- **Related** https://github.com/xhd2015/xgo/issues/330 — fatal/`-race` failures; checkptr side was already mitigated earlier; this addresses remaining inherit/g-lifecycle races under `-race` without forcing `--xgo-race-safe`.

## Test plan

- [x] RED: `race_inherit` under `-race` failed with many DATA RACEs (including `inerhitStack` / `G.Set` vs child `G.Get`) before the fix
- [x] GREEN: `go run -tags dev ./cmd/xgo test -race --project-dir runtime/test/trace/go_trace/race_inherit ./` (and `-count=2`)
- [x] GREEN: `go run ./script/run-test --include go1.25.10 ./runtime/test/trace/go_trace/race_inherit`
- [x] GREEN: existing `with_race` fixture still passes with `-race --xgo-race-safe`
- [ ] CI on this PR