### PR TITLE
feat: mock-rule-include-as-main-module for multi-module mock rules

### DIFF
--- a/cmd/xgo/include_as_main_module_parse_test.go
+++ b/cmd/xgo/include_as_main_module_parse_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseModuleList(t *testing.T) {
+	got := parseModuleList(" a , b,a, ")
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestParseOptions_IncludeAsMainModule_Flag(t *testing.T) {
+	opts, err := parseOptions("test", []string{
+		"--mock-rule-include-as-main-module=example.com/app,example.com/lib",
+		"./...",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.mockRuleIncludeAsMainModule != "example.com/app,example.com/lib" {
+		t.Fatalf("flag effective: %q", opts.mockRuleIncludeAsMainModule)
+	}
+}
+
+func TestParseOptions_IncludeAsMainModule_EnvFallback(t *testing.T) {
+	os.Setenv("XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE", "example.com/fromenv")
+	defer os.Unsetenv("XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE")
+	opts, err := parseOptions("test", []string{"./..."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.mockRuleIncludeAsMainModule != "example.com/fromenv" {
+		t.Fatalf("env effective: %q", opts.mockRuleIncludeAsMainModule)
+	}
+}
+
+func TestParseOptions_IncludeAsMainModule_FlagWinsEnv(t *testing.T) {
+	os.Setenv("XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE", "example.com/fromenv")
+	defer os.Unsetenv("XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE")
+	opts, err := parseOptions("test", []string{
+		"--mock-rule-include-as-main-module=example.com/fromflag",
+		"./...",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.mockRuleIncludeAsMainModule != "example.com/fromflag" {
+		t.Fatalf("flag should win: %q", opts.mockRuleIncludeAsMainModule)
+	}
+}
+
+func TestPkgWithinAnyModule(t *testing.T) {
+	if !pkgWithinAnyModule("example.com/app/foo", "example.com/suite", []string{"example.com/app"}) {
+		t.Fatal("expected app/foo under app")
+	}
+	if pkgWithinAnyModule("example.com/other/x", "example.com/suite", []string{"example.com/app"}) {
+		t.Fatal("other should not match")
+	}
+}

--- a/cmd/xgo/instrument.go
+++ b/cmd/xgo/instrument.go
@@ -48,8 +48,10 @@ type instrumentResult struct {
 }
 
 // goroot is critical for stdlib
-func instrumentUserCode(goroot string, projectDir string, projectRoot string, goVersion *goinfo.GoVersion, xgoSrc string, mod string, modfile string, mainModule string, xgoRuntimeModuleDir string, mayHaveCover bool, overlayFS overlay.Overlay, includeTest bool, rules []Rule, trapPkgs []string, trapAll string, collectTestTrace bool, collectTestTraceDir string, xgoRaceSafe bool, goFlag bool, triedUpgrade bool) (*instrumentResult, error) {
-	logDebug("instrumentUserSpace: mod=%s, modfile=%s, xgoRuntimeModuleDir=%s, includeTest=%v, collectTestTrace=%v", mod, modfile, xgoRuntimeModuleDir, includeTest, collectTestTrace)
+// includeAsMainModules: extra module paths treated as main for mock/trap (option B:
+// reclassify packages already on the load graph; do not bulk-load module/...).
+func instrumentUserCode(goroot string, projectDir string, projectRoot string, goVersion *goinfo.GoVersion, xgoSrc string, mod string, modfile string, mainModule string, includeAsMainModules []string, xgoRuntimeModuleDir string, mayHaveCover bool, overlayFS overlay.Overlay, includeTest bool, rules []Rule, trapPkgs []string, trapAll string, collectTestTrace bool, collectTestTraceDir string, xgoRaceSafe bool, goFlag bool, triedUpgrade bool) (*instrumentResult, error) {
+	logDebug("instrumentUserSpace: mod=%s, modfile=%s, xgoRuntimeModuleDir=%s, includeTest=%v, collectTestTrace=%v, includeAsMainModules=%v", mod, modfile, xgoRuntimeModuleDir, includeTest, collectTestTrace, includeAsMainModules)
 	if mod == "" {
 		// check vendor dir
 		vendorDir, err := getVendorDir(projectRoot)
@@ -168,7 +170,7 @@ func instrumentUserCode(goroot string, projectDir string, projectRoot string, go
 	var mainCnt int
 	for _, pkg := range pkgs.Packages {
 		pkgPath := pkg.LoadPackage.GoPackage.ImportPath
-		_, isMain := goinfo.PkgWithinModule(pkgPath, mainModule)
+		isMain := pkgWithinAnyModule(pkgPath, mainModule, includeAsMainModules)
 		if isMain {
 			pkg.Main = true
 			mainCnt++
@@ -211,6 +213,35 @@ func instrumentUserCode(goroot string, projectDir string, projectRoot string, go
 		return nil, err
 	}
 	logDebug("traverse: cost=%v", time.Since(traverseBegin))
+
+	// Option B: reclassify packages loaded during traverse (deps pulled by
+	// imports/mock-refs) as main when they fall under include-as modules.
+	// Initial load often does not yet include those packages.
+	if len(includeAsMainModules) > 0 {
+		var extraMain int
+		for _, pkg := range pkgs.Packages {
+			if pkg.Main {
+				continue
+			}
+			pkgPath := pkg.LoadPackage.GoPackage.ImportPath
+			if pkgWithinAnyModule(pkgPath, "", includeAsMainModules) {
+				pkg.Main = true
+				extraMain++
+				logDebug("instrument: post-traverse include-as-main pkg=%s", pkgPath)
+			}
+		}
+		if extraMain > 0 {
+			logDebug("instrument: post-traverse extra main pkgs=%d", extraMain)
+			// Collect decls on newly main packages so var trap / resolve stay consistent.
+			newMainPkgs := pkgs.Filter(func(pkg *edit.Package) bool {
+				return pkg.Main && pkg.AllowInstrument
+			})
+			for _, pkg := range newMainPkgs {
+				resolve.CollectDecls(pkg)
+			}
+			mainPkgs = newMainPkgs
+		}
+	}
 
 	logDebug("start instrumentVarTrap: len(mainPkgs)=%d", len(mainPkgs))
 	err = instrument_var.TrapVariables(pkgs, &recorder)
@@ -479,6 +510,25 @@ func splitCommaList(s string) []string {
 		trimmedList = append(trimmedList, item)
 	}
 	return trimmedList
+}
+
+// pkgWithinAnyModule reports whether pkgPath is under realMain or any extra
+// module path (mock-rule include-as-main-module, additive).
+func pkgWithinAnyModule(pkgPath string, realMain string, extras []string) bool {
+	if realMain != "" {
+		if _, ok := goinfo.PkgWithinModule(pkgPath, realMain); ok {
+			return true
+		}
+	}
+	for _, m := range extras {
+		if m == "" || m == realMain {
+			continue
+		}
+		if _, ok := goinfo.PkgWithinModule(pkgPath, m); ok {
+			return true
+		}
+	}
+	return false
 }
 
 func setupLocalXgoGenDir(xgoGenDir string) error {

--- a/cmd/xgo/main.go
+++ b/cmd/xgo/main.go
@@ -430,7 +430,8 @@ func handleBuild(cmd string, args []string) error {
 		instrumentedGorootNeedRecreate = false
 	}
 
-	optionsFromFile, optionsFromFileContent, err := mergeOptionFiles(sessionTmpDir, opts.optionsFromFile, opts.mockRules)
+	includeAsMainModules := parseModuleList(opts.mockRuleIncludeAsMainModule)
+	optionsFromFile, optionsFromFileContent, err := mergeOptionFiles(sessionTmpDir, opts.optionsFromFile, opts.mockRules, includeAsMainModules)
 	if err != nil {
 		return err
 	}
@@ -773,7 +774,12 @@ xgo will try best to compile with newer xgo/runtime v%s, it's recommended to upg
 			collectTestTrace = true
 			collectTestTraceDir = stackTraceDir
 		}
-		instrumentUserCodeResult, err = instrumentUserCode(instrumentGoroot, projectDir, projectRoot, goVersion, realXgoSrc, modForLoad, modfileForLoad, mainModule, xgoRuntimeModuleDir, mayHaveCover, overlayFS, cmdTest, opts.FilterRules, trapPkgs, trapAll, collectTestTrace, collectTestTraceDir, xgoRaceSafe, goFlag, needUpgrade)
+		// Prefer CLI/env effective list; fall back to list already in options file if any.
+		instrumentIncludeAsMain := includeAsMainModules
+		if len(instrumentIncludeAsMain) == 0 {
+			instrumentIncludeAsMain = opts.MockRuleIncludeAsMainModule
+		}
+		instrumentUserCodeResult, err = instrumentUserCode(instrumentGoroot, projectDir, projectRoot, goVersion, realXgoSrc, modForLoad, modfileForLoad, mainModule, instrumentIncludeAsMain, xgoRuntimeModuleDir, mayHaveCover, overlayFS, cmdTest, opts.FilterRules, trapPkgs, trapAll, collectTestTrace, collectTestTraceDir, xgoRaceSafe, goFlag, needUpgrade)
 		if err != nil {
 			return err
 		}

--- a/cmd/xgo/option.go
+++ b/cmd/xgo/option.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/xhd2015/xgo/support/flag"
@@ -43,6 +44,11 @@ type options struct {
 	// amend the --options-from-file.
 	// it will take higher priority
 	mockRules []string
+	// --mock-rule-include-as-main-module / XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE:
+	// effective comma-separated module paths (flag wins over env) that count as
+	// main for mock_rules main_module matching / related instrumentation only
+	// (additive to the real process main module). Empty = real main only.
+	mockRuleIncludeAsMainModule string
 	// dev only
 	debugWithDlv bool
 	xgoHome      string
@@ -145,6 +151,7 @@ func parseOptions(cmd string, args []string) (*options, error) {
 
 	var optionsFromFile string
 	var mockRules []string
+	var mockRuleIncludeAsMainModule string
 
 	var debugWithDlv bool
 	var xgoHome string
@@ -238,6 +245,10 @@ func parseOptions(cmd string, args []string) (*options, error) {
 			Set: func(v string) {
 				mockRules = append(mockRules, v)
 			},
+		},
+		{
+			Flags: []string{"--mock-rule-include-as-main-module"},
+			Value: &mockRuleIncludeAsMainModule,
 		},
 		{
 			Flags: []string{"--dump-ir"},
@@ -611,6 +622,8 @@ func parseOptions(cmd string, args []string) (*options, error) {
 
 		optionsFromFile: optionsFromFile,
 		mockRules:       mockRules,
+		// Effective list: flag replaces env (whole string); empty flag falls back to env.
+		mockRuleIncludeAsMainModule: firstNonEmpty(mockRuleIncludeAsMainModule, os.Getenv("XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE")),
 
 		debugWithDlv: debugWithDlv,
 		xgoHome:      xgoHome,
@@ -647,6 +660,15 @@ func parseOptions(cmd string, args []string) (*options, error) {
 		patchGorootInPlace:  patchGorootInPlace,
 		skipRebuildCompilerAndGo: skipRebuildCompilerAndGo,
 	}, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // parse: --opt=x, --opt x, --opt, but not --opt -x

--- a/cmd/xgo/rule.go
+++ b/cmd/xgo/rule.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/xhd2015/xgo/support/fileutil"
 )
@@ -24,12 +25,36 @@ type Rule struct {
 	Action     string  `json:"action"` // include,exclude or empty
 }
 
+// FileOptions is written to options-from-file.json for the instrumented compiler
+// (XGO_COMPILER_OPTIONS_FILE). Keep in sync with patch/legacy/ctxt.Options.
 type FileOptions struct {
 	FilterRules []Rule `json:"filter_rules"`
+	// MockRuleIncludeAsMainModule is additive module paths treated as main for
+	// mock_rules main_module matching only (not process XGO_MAIN_MODULE).
+	MockRuleIncludeAsMainModule []string `json:"mock_rule_include_as_main_module,omitempty"`
 }
 
-func mergeOptionFiles(tmpDir string, optionFromFile string, mockRules []string) (newFile string, content []byte, err error) {
-	if len(mockRules) == 0 {
+// parseModuleList splits a comma-separated module list (CLI/env form).
+func parseModuleList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return out
+}
+
+func mergeOptionFiles(tmpDir string, optionFromFile string, mockRules []string, includeAsMainModules []string) (newFile string, content []byte, err error) {
+	if len(mockRules) == 0 && len(includeAsMainModules) == 0 {
 		if optionFromFile != "" {
 			content, err = fileutil.ReadFile(optionFromFile)
 		}
@@ -65,8 +90,12 @@ func mergeOptionFiles(tmpDir string, optionFromFile string, mockRules []string) 
 	}
 
 	mergedRules = append(mergedRules, rulesFromFiles...)
+	opts.FilterRules = mergedRules
+	if len(includeAsMainModules) > 0 {
+		opts.MockRuleIncludeAsMainModule = includeAsMainModules
+	}
 
-	newOptionFile, err := json.Marshal(FileOptions{FilterRules: mergedRules})
+	newOptionFile, err := json.Marshal(opts)
 	if err != nil {
 		return "", nil, err
 	}

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -7,8 +7,8 @@ import "fmt"
 // VERSION is manually updated when needed a new tag
 // if you did not install git hooks, you can manually update them
 const VERSION = "1.2.2"
-const REVISION = "f3b27d0a155caf0e5da9133597179c5518e794d4+1"
-const NUMBER = 643
+const REVISION = "8028d2720e6f690c62dc7829ad495efd6fb0805f+1"
+const NUMBER = 644
 
 // Rationale: xgo consists of these modules:
 //

--- a/patch/legacy/ctxt/match.go
+++ b/patch/legacy/ctxt/match.go
@@ -33,7 +33,26 @@ func init() {
 }
 
 func GetAction(fn *info.DeclInfo) string {
-	return match.MatchRules(opts.FilterRules, GetPkgPath(), isMainModule, fn)
+	return match.MatchRules(opts.FilterRules, GetPkgPath(), isMainForMock(), fn)
+}
+
+// isMainForMock is true when the package under compile counts as main for
+// mock_rules main_module matching: real process main (XGO_MAIN_MODULE) or any
+// path listed in options-from-file mock_rule_include_as_main_module.
+func isMainForMock() bool {
+	if isMainModule {
+		return true
+	}
+	pkg := GetPkgPath()
+	for _, m := range opts.MockRuleIncludeAsMainModule {
+		if m == "" {
+			continue
+		}
+		if IsSameModule(pkg, m) {
+			return true
+		}
+	}
+	return false
 }
 
 func MatchAnyPattern(pkgPath string, pkgName string, funcName string, patterns []string) bool {

--- a/patch/legacy/ctxt/match_options.go
+++ b/patch/legacy/ctxt/match_options.go
@@ -2,6 +2,10 @@ package ctxt
 
 import "cmd/compile/internal/xgo_rewrite_internal/patch/match"
 
+// Options is read from XGO_COMPILER_OPTIONS_FILE (options-from-file.json).
+// Keep in sync with cmd/xgo.FileOptions.
 type Options struct {
 	FilterRules []match.Rule `json:"filter_rules"`
+	// MockRuleIncludeAsMainModule: additive module paths for main_module rules.
+	MockRuleIncludeAsMainModule []string `json:"mock_rule_include_as_main_module,omitempty"`
 }

--- a/runtime/test/mock/mock_rule_include_as_main_module/README.md
+++ b/runtime/test/mock/mock_rule_include_as_main_module/README.md
@@ -1,0 +1,38 @@
+# mock_rule_include_as_main_module
+
+Integration tests for `--mock-rule-include-as-main-module` /
+`XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE`.
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `app/`, `lib/`, `other/` | Replace-deps (not process main) |
+| `without/` | Baseline: main_module rules only → suite OK, app/other fail |
+| `with_flag/` | Flag includes `app` |
+| `with_env/` | Env includes `app` |
+| `flag_overrides_env/` | Flag=`app`, env=`lib` → flag wins whole list |
+| `with_flag_two_modules/` | Flag=`app,lib` |
+
+Each suite uses pricing-like rules:
+
+```text
+--mock-rule {"main_module":true,"kind":"func","action":"include"}
+--mock-rule {"any":true,"action":"exclude"}
+```
+
+## Run
+
+From the xgo repo root:
+
+```bash
+go run ./script/run-test ./runtime/test/mock/mock_rule_include_as_main_module/without
+go run ./script/run-test ./runtime/test/mock/mock_rule_include_as_main_module/with_flag
+# …
+```
+
+## Testing note
+
+Third-party `mock.Patch` targets go through an `interface{}` helper so static
+mock-ref analysis does **not** auto-instrument them. Direct `mock.Patch(app.Hello, …)`
+would instrument `app` even without include-as and would false-green these tests.

--- a/runtime/test/mock/mock_rule_include_as_main_module/app/app.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/app/app.go
@@ -1,0 +1,7 @@
+package app
+
+// Hello is a third-module function intended for mock.Patch under
+// --mock-rule-include-as-main-module (or the matching env).
+func Hello() string {
+	return "app-hello"
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/app/go.mod
+++ b/runtime/test/mock/mock_rule_include_as_main_module/app/go.mod
@@ -1,0 +1,3 @@
+module github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app
+
+go 1.18

--- a/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env/go.mod
+++ b/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env/go.mod
@@ -1,0 +1,17 @@
+module github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env
+
+go 1.18
+
+require (
+	github.com/xhd2015/xgo/runtime v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib v0.0.0
+)
+
+replace github.com/xhd2015/xgo/runtime => ../../../../
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app => ../app
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib => ../lib
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other => ../other

--- a/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env/suite.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env/suite.go
@@ -1,0 +1,6 @@
+package flag_overrides_env
+
+// LocalHello lives in the real process main module (this suite).
+func LocalHello() string {
+	return "suite-hello"
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env/suite_test.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env/suite_test.go
@@ -1,0 +1,56 @@
+package flag_overrides_env
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/mock"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib"
+)
+
+// Flag list is app; env list is lib. Flag must win the whole list (not merge):
+// app mockable via main_module, lib not.
+
+func TestLocalPatchOK(t *testing.T) {
+	mock.Patch(LocalHello, func() string { return "mock-local" })
+	if got := LocalHello(); got != "mock-local" {
+		t.Fatalf("LocalHello: want mock-local, got %q", got)
+	}
+}
+
+func TestAppPatchOK(t *testing.T) {
+	expectPatchOK(t, app.Hello, app.Hello, "mock-app")
+}
+
+func TestLibPatchFails(t *testing.T) {
+	expectPatchFail(t, lib.Hello)
+}
+
+func expectPatchOK(t *testing.T, fn interface{}, call func() string, want string) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return want })
+	}()
+	if panicErr != nil {
+		t.Fatalf("expect mock.Patch to succeed (include-as-main-module should instrument target), panic: %v", panicErr)
+	}
+	if got := call(); got != want {
+		t.Fatalf("patched call: want %q, got %q", want, got)
+	}
+}
+
+func expectPatchFail(t *testing.T, fn interface{}) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return "should-not-apply" })
+	}()
+	if panicErr == nil {
+		t.Fatalf("expect mock.Patch to panic for non-instrumented target, actual nil")
+	}
+	t.Logf("got expected panic: %s", fmt.Sprint(panicErr))
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env/test-config.txt
+++ b/runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env/test-config.txt
@@ -1,0 +1,3 @@
+# Flag replaces env list entirely (flag=app, env=lib → only app is extra main).
+flags: --mock-rule {"main_module":true,"kind":"func","action":"include"} --mock-rule {"any":true,"action":"exclude"} --mock-rule-include-as-main-module=github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app
+env: XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE=github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib

--- a/runtime/test/mock/mock_rule_include_as_main_module/lib/go.mod
+++ b/runtime/test/mock/mock_rule_include_as_main_module/lib/go.mod
@@ -1,0 +1,3 @@
+module github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib
+
+go 1.18

--- a/runtime/test/mock/mock_rule_include_as_main_module/lib/lib.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/lib/lib.go
@@ -1,0 +1,7 @@
+package lib
+
+// Hello is a second replace dependency used for multi-module include lists
+// and flag-vs-env override cases.
+func Hello() string {
+	return "lib-hello"
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/other/go.mod
+++ b/runtime/test/mock/mock_rule_include_as_main_module/other/go.mod
@@ -1,0 +1,3 @@
+module github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other
+
+go 1.18

--- a/runtime/test/mock/mock_rule_include_as_main_module/other/other.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/other/other.go
@@ -1,0 +1,7 @@
+package other
+
+// Hello is a dependency that is never listed in include-as-main-module.
+// With main_module-only include rules, mock.Patch must keep failing.
+func Hello() string {
+	return "other-hello"
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_env/go.mod
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_env/go.mod
@@ -1,0 +1,17 @@
+module github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/with_env
+
+go 1.18
+
+require (
+	github.com/xhd2015/xgo/runtime v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other v0.0.0
+)
+
+replace github.com/xhd2015/xgo/runtime => ../../../../
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app => ../app
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib => ../lib
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other => ../other

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_env/suite.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_env/suite.go
@@ -1,0 +1,6 @@
+package with_env
+
+// LocalHello lives in the real process main module (this suite).
+func LocalHello() string {
+	return "suite-hello"
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_env/suite_test.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_env/suite_test.go
@@ -1,0 +1,55 @@
+package with_env
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/mock"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other"
+)
+
+// Same expectations as with_flag; include list comes from env only.
+
+func TestLocalPatchOK(t *testing.T) {
+	mock.Patch(LocalHello, func() string { return "mock-local" })
+	if got := LocalHello(); got != "mock-local" {
+		t.Fatalf("LocalHello: want mock-local, got %q", got)
+	}
+}
+
+func TestAppPatchOK(t *testing.T) {
+	expectPatchOK(t, app.Hello, app.Hello, "mock-app")
+}
+
+func TestOtherPatchFails(t *testing.T) {
+	expectPatchFail(t, other.Hello)
+}
+
+func expectPatchOK(t *testing.T, fn interface{}, call func() string, want string) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return want })
+	}()
+	if panicErr != nil {
+		t.Fatalf("expect mock.Patch to succeed (include-as-main-module should instrument target), panic: %v", panicErr)
+	}
+	if got := call(); got != want {
+		t.Fatalf("patched call: want %q, got %q", want, got)
+	}
+}
+
+func expectPatchFail(t *testing.T, fn interface{}) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return "should-not-apply" })
+	}()
+	if panicErr == nil {
+		t.Fatalf("expect mock.Patch to panic for non-instrumented target, actual nil")
+	}
+	t.Logf("got expected panic: %s", fmt.Sprint(panicErr))
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_env/test-config.txt
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_env/test-config.txt
@@ -1,0 +1,3 @@
+# Env-only include-as-main-module (no flag).
+flags: --mock-rule {"main_module":true,"kind":"func","action":"include"} --mock-rule {"any":true,"action":"exclude"}
+env: XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE=github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_flag/go.mod
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_flag/go.mod
@@ -1,0 +1,17 @@
+module github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/with_flag
+
+go 1.18
+
+require (
+	github.com/xhd2015/xgo/runtime v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other v0.0.0
+)
+
+replace github.com/xhd2015/xgo/runtime => ../../../../
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app => ../app
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib => ../lib
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other => ../other

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_flag/suite.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_flag/suite.go
@@ -1,0 +1,6 @@
+package with_flag
+
+// LocalHello lives in the real process main module (this suite).
+func LocalHello() string {
+	return "suite-hello"
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_flag/suite_test.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_flag/suite_test.go
@@ -1,0 +1,59 @@
+package with_flag
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/mock"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other"
+)
+
+// With --mock-rule-include-as-main-module=.../app, main_module rules should
+// treat app like main (InstrumentMode_All) so indirect mock.Patch works.
+// Real main (suite) stays mockable; other does not.
+
+func TestLocalPatchOK(t *testing.T) {
+	mock.Patch(LocalHello, func() string { return "mock-local" })
+	if got := LocalHello(); got != "mock-local" {
+		t.Fatalf("LocalHello: want mock-local, got %q", got)
+	}
+}
+
+func TestAppPatchOK(t *testing.T) {
+	// Must use interface{} helper: direct mock.Patch(app.Hello) auto-instruments
+	// via mock-ref and would false-green without include-as.
+	expectPatchOK(t, app.Hello, app.Hello, "mock-app")
+}
+
+func TestOtherPatchFails(t *testing.T) {
+	expectPatchFail(t, other.Hello)
+}
+
+func expectPatchOK(t *testing.T, fn interface{}, call func() string, want string) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return want })
+	}()
+	if panicErr != nil {
+		t.Fatalf("expect mock.Patch to succeed (include-as-main-module should instrument target), panic: %v", panicErr)
+	}
+	if got := call(); got != want {
+		t.Fatalf("patched call: want %q, got %q", want, got)
+	}
+}
+
+func expectPatchFail(t *testing.T, fn interface{}) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return "should-not-apply" })
+	}()
+	if panicErr == nil {
+		t.Fatalf("expect mock.Patch to panic for non-instrumented target, actual nil")
+	}
+	t.Logf("got expected panic: %s", fmt.Sprint(panicErr))
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_flag/test-config.txt
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_flag/test-config.txt
@@ -1,0 +1,2 @@
+# Hero case: flag includes app as main for mock_rules only.
+flags: --mock-rule {"main_module":true,"kind":"func","action":"include"} --mock-rule {"any":true,"action":"exclude"} --mock-rule-include-as-main-module=github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules/go.mod
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules/go.mod
@@ -1,0 +1,18 @@
+module github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules
+
+go 1.18
+
+require (
+	github.com/xhd2015/xgo/runtime v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other v0.0.0
+)
+
+replace github.com/xhd2015/xgo/runtime => ../../../../
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app => ../app
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib => ../lib
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other => ../other

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules/suite.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules/suite.go
@@ -1,0 +1,6 @@
+package with_flag_two_modules
+
+// LocalHello lives in the real process main module (this suite).
+func LocalHello() string {
+	return "suite-hello"
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules/suite_test.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules/suite_test.go
@@ -1,0 +1,60 @@
+package with_flag_two_modules
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/mock"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other"
+)
+
+// Comma-separated include list: app and lib both extra main; other not.
+
+func TestLocalPatchOK(t *testing.T) {
+	mock.Patch(LocalHello, func() string { return "mock-local" })
+	if got := LocalHello(); got != "mock-local" {
+		t.Fatalf("LocalHello: want mock-local, got %q", got)
+	}
+}
+
+func TestAppPatchOK(t *testing.T) {
+	expectPatchOK(t, app.Hello, app.Hello, "mock-app")
+}
+
+func TestLibPatchOK(t *testing.T) {
+	expectPatchOK(t, lib.Hello, lib.Hello, "mock-lib")
+}
+
+func TestOtherPatchFails(t *testing.T) {
+	expectPatchFail(t, other.Hello)
+}
+
+func expectPatchOK(t *testing.T, fn interface{}, call func() string, want string) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return want })
+	}()
+	if panicErr != nil {
+		t.Fatalf("expect mock.Patch to succeed (include-as-main-module should instrument target), panic: %v", panicErr)
+	}
+	if got := call(); got != want {
+		t.Fatalf("patched call: want %q, got %q", want, got)
+	}
+}
+
+func expectPatchFail(t *testing.T, fn interface{}) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return "should-not-apply" })
+	}()
+	if panicErr == nil {
+		t.Fatalf("expect mock.Patch to panic for non-instrumented target, actual nil")
+	}
+	t.Logf("got expected panic: %s", fmt.Sprint(panicErr))
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules/test-config.txt
+++ b/runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules/test-config.txt
@@ -1,0 +1,2 @@
+# Two extra main modules via comma-separated flag value.
+flags: --mock-rule {"main_module":true,"kind":"func","action":"include"} --mock-rule {"any":true,"action":"exclude"} --mock-rule-include-as-main-module=github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app,github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib

--- a/runtime/test/mock/mock_rule_include_as_main_module/without/go.mod
+++ b/runtime/test/mock/mock_rule_include_as_main_module/without/go.mod
@@ -1,0 +1,17 @@
+module github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/without
+
+go 1.18
+
+require (
+	github.com/xhd2015/xgo/runtime v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app v0.0.0
+	github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other v0.0.0
+)
+
+replace github.com/xhd2015/xgo/runtime => ../../../../
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app => ../app
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/lib => ../lib
+
+replace github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other => ../other

--- a/runtime/test/mock/mock_rule_include_as_main_module/without/suite.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/without/suite.go
@@ -1,0 +1,6 @@
+package without
+
+// LocalHello lives in the real process main module (this suite).
+func LocalHello() string {
+	return "suite-hello"
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/without/suite_test.go
+++ b/runtime/test/mock/mock_rule_include_as_main_module/without/suite_test.go
@@ -1,0 +1,45 @@
+package without
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/mock"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/app"
+	"github.com/xhd2015/xgo/runtime/test/mock/mock_rule_include_as_main_module/other"
+)
+
+// Baseline: main_module-only rules, no include-as.
+//
+// Important: third-party mock.Patch targets must go through an interface{}
+// helper so static mock-ref analysis does NOT auto-instrument them. Direct
+// mock.Patch(app.Hello, ...) would instrument app regardless of main_module
+// rules and would not test include-as-main-module.
+
+func TestLocalPatchOK(t *testing.T) {
+	mock.Patch(LocalHello, func() string { return "mock-local" })
+	if got := LocalHello(); got != "mock-local" {
+		t.Fatalf("LocalHello: want mock-local, got %q", got)
+	}
+}
+
+func TestAppPatchFails(t *testing.T) {
+	expectPatchFail(t, app.Hello)
+}
+
+func TestOtherPatchFails(t *testing.T) {
+	expectPatchFail(t, other.Hello)
+}
+
+func expectPatchFail(t *testing.T, fn interface{}) {
+	t.Helper()
+	var panicErr interface{}
+	func() {
+		defer func() { panicErr = recover() }()
+		mock.Patch(fn, func() string { return "should-not-apply" })
+	}()
+	if panicErr == nil {
+		t.Fatalf("expect mock.Patch to panic for non-instrumented target, actual nil")
+	}
+	t.Logf("got expected panic: %s", fmt.Sprint(panicErr))
+}

--- a/runtime/test/mock/mock_rule_include_as_main_module/without/test-config.txt
+++ b/runtime/test/mock/mock_rule_include_as_main_module/without/test-config.txt
@@ -1,0 +1,3 @@
+# Pricing-like mock rules: only main_module funcs, then exclude all else.
+# No --mock-rule-include-as-main-module: app must stay unmockable.
+flags: --mock-rule {"main_module":true,"kind":"func","action":"include"} --mock-rule {"any":true,"action":"exclude"}


### PR DESCRIPTION
## Summary

- Add `--mock-rule-include-as-main-module` / `XGO_MOCK_RULE_INCLUDE_AS_MAIN_MODULE` (flag wins over env) so extra module paths can count as main for `mock_rules` `main_module` matching and related instrumentation.
- Does **not** rewrite process `XGO_MAIN_MODULE` / `ResolveMainModule`; list is additive to the real process main module.
- Writes `mock_rule_include_as_main_module` as a JSON array into options-from-file for the compiler (`GetAction` / MatchRules); no new compiler env.
- Instrument side reclassifies packages already on the load graph (including deps loaded during traverse) as main when under listed modules.

This unblocks multi-module layouts (e.g. doctest gen suite with project as replace dep) that reuse pricing-style `main_module: true` mock rules without `--trap-all`.

## Test plan

- [x] `go test ./cmd/xgo -run 'TestParseModuleList|TestParseOptions_Include|TestPkgWithin' -count=1`
- [x] `go run ./script/run-test ./runtime/test/mock/mock_rule_include_as_main_module/without`
- [x] `go run ./script/run-test ./runtime/test/mock/mock_rule_include_as_main_module/with_flag`
- [x] `go run ./script/run-test ./runtime/test/mock/mock_rule_include_as_main_module/with_env`
- [x] `go run ./script/run-test ./runtime/test/mock/mock_rule_include_as_main_module/flag_overrides_env`
- [x] `go run ./script/run-test ./runtime/test/mock/mock_rule_include_as_main_module/with_flag_two_modules`