### PR TITLE
test: pin loose-JSON gap on go1.27 json v2

### DIFF
--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -7,8 +7,8 @@ import "fmt"
 // VERSION is manually updated when needed a new tag
 // if you did not install git hooks, you can manually update them
 const VERSION = "1.2.6"
-const REVISION = "3d8fddcc45848d584a38f5c045a84b489c54d847+1"
-const NUMBER = 669
+const REVISION = "c906dcfe6351f5c093f4c897d33b009d2fe42db4+1"
+const NUMBER = 670
 
 // Rationale: xgo consists of these modules:
 //

--- a/runtime/test/trace/marshal/loose/loose_json_test.go
+++ b/runtime/test/trace/marshal/loose/loose_json_test.go
@@ -1,0 +1,104 @@
+// Package loose pins the modern loose-JSON contract used by xgo trace:
+// unsupported types (func, chan, …) must marshal as placeholders under
+// runtime.MarshalNoError, not soft-fail into {"error":"…unsupported…"}.
+//
+// Expected behavior with an instrumented GOROOT:
+//   - go1.26 and earlier (classic encoding/json + unsupportedTypeEncoder patch): PASS
+//   - go1.27 default (json v2 / makeInvalidArshaler, patch not yet applied): FAIL
+//
+// Run via:
+//
+//	go run ./script/run-test --include go1.26 -run TestLooseJsonMarshal ./runtime/test/trace/marshal/loose
+//	go run ./script/run-test --include go1.27rc2 -run TestLooseJsonMarshal ./runtime/test/trace/marshal/loose
+package loose
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xhd2015/xgo/runtime/trace"
+	"github.com/xhd2015/xgo/runtime/trace/stack_model"
+)
+
+// holder mixes a marshalable field with an unsupported one so nested
+// encoding is exercised (not only a bare unsupported root value).
+type holder struct {
+	N int
+	F func()
+	C chan int
+}
+
+func TestLooseJsonMarshalUnsupportedFunc(t *testing.T) {
+	assertLoosePlaceholder(t, func() (interface{}, error) {
+		return func() {}, nil
+	}, "func()")
+}
+
+func TestLooseJsonMarshalUnsupportedChan(t *testing.T) {
+	assertLoosePlaceholder(t, func() (interface{}, error) {
+		return make(chan int), nil
+	}, "chan int")
+}
+
+func TestLooseJsonMarshalUnsupportedNested(t *testing.T) {
+	assertLoosePlaceholder(t, func() (interface{}, error) {
+		return holder{N: 42, F: func() {}, C: make(chan int)}, nil
+	}, "func()", "chan int")
+	// Nested case: the int field must survive when loose marshaling works.
+	data := captureTraceJSON(t, func() (interface{}, error) {
+		return holder{N: 42, F: func() {}, C: make(chan int)}, nil
+	})
+	if !strings.Contains(data, `"N":42`) && !strings.Contains(data, `"N": 42`) {
+		// Soft-fail of the whole value often loses the sibling field.
+		t.Errorf("expect nested int field N=42 preserved under loose marshaling, got %q", data)
+	}
+}
+
+func assertLoosePlaceholder(t *testing.T, body func() (interface{}, error), typeHints ...string) {
+	t.Helper()
+	data := captureTraceJSON(t, body)
+
+	// MarshalNoError soft-fail form when the stdlib encoder rejects the value
+	// (go1.27 default today: json v2 path, no loose hook on makeInvalidArshaler).
+	if strings.Contains(data, `"error"`) && strings.Contains(strings.ToLower(data), "unsupported") {
+		t.Fatalf("loose JSON marshaling did not engage: got soft-fail error form %q\n"+
+			"hint: on go1.27+ default (json v2), encoding/json/encode.go patch is inactive; "+
+			"need a makeInvalidArshaler (or equivalent) hook", data)
+	}
+
+	// Path-A placeholder from patched unsupportedTypeEncoder:
+	//   e.WriteString(fmt.Sprintf("{%q:%q}", v.Type().String(), "?"))
+	// e.g. {"func()":"?"} or {"chan int":"?"}
+	if !strings.Contains(data, `"?`) && !strings.Contains(data, `":"?"`) && !strings.Contains(data, `": "?"`) {
+		t.Fatalf("expect loose placeholder containing \"?\", got %q", data)
+	}
+	for _, hint := range typeHints {
+		if hint == "" {
+			continue
+		}
+		if !strings.Contains(data, hint) {
+			t.Errorf("expect type hint %q in loose placeholder JSON, got %q", hint, data)
+		}
+	}
+}
+
+func captureTraceJSON(t *testing.T, body func() (interface{}, error)) string {
+	t.Helper()
+	var exported stack_model.IStack
+	trace.Trace(trace.Config{
+		OnFinish: func(stack stack_model.IStack) {
+			exported = stack
+		},
+	}, nil, body)
+	if exported == nil {
+		t.Fatal("OnFinish did not capture stack")
+	}
+	data, err := exported.JSON()
+	if err != nil {
+		t.Fatalf("stack.JSON: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("stack.JSON returned empty")
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary

- Adds `runtime/test/trace/marshal/loose` contract tests for xgo's modern loose-JSON path (`MarshalNoError` via `trace.Trace` / stack `JSON()`).
- Asserts unsupported types (`func`, `chan`, nested) marshal as placeholders (`"?"`), not soft-fail `{"error":"…unsupported…"}`.
- **Expected:** PASS on go1.26 (classic `unsupportedTypeEncoder` patch); FAIL on go1.27 default until a json/v2 (`makeInvalidArshaler`) hook lands.

## Context

Go 1.27 defaults to `encoding/json` backed by v2. The existing loose-JSON patch targets `encode.go` (`//go:build !goexperiment.jsonv2`), which is inactive by default. These tests pin that gap so go1.27 CI goes red until fixed.

## Test plan

- [x] `go run ./script/run-test --include go1.26.5 --install-xgo --with-setup -v -run TestLooseJsonMarshal ./runtime/test/trace/marshal/loose` → PASS
- [x] `go run ./script/run-test --include go1.27rc2 --install-xgo --with-setup -v -run TestLooseJsonMarshal ./runtime/test/trace/marshal/loose` → FAIL (documents the gap)
- [ ] CI go1-26 remains green; go1-27 red on this package until the v2 patch lands