### PR TITLE
feat(testconfig): shared test.config.json parse and go min/max validation

### DIFF
--- a/cmd/xgo/test-explorer/config.go
+++ b/cmd/xgo/test-explorer/config.go
@@ -1,7 +1,6 @@
 package test_explorer
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -10,193 +9,26 @@ import (
 
 	"github.com/xhd2015/xgo/support/cmd"
 	"github.com/xhd2015/xgo/support/fileutil"
-	"github.com/xhd2015/xgo/support/goinfo"
+	"github.com/xhd2015/xgo/support/testconfig"
 )
 
-type TestConfig struct {
-	Go      *GoConfig              `json:"go"`
-	GoCmd   string                 `json:"go_cmd"`
-	Exclude []string               `json:"exclude"`
-	Env     map[string]interface{} `json:"env"`
+// TestConfig is the explorer view of shared test.config.json.
+type TestConfig = testconfig.Config
 
-	// test flags passed to go test
-	// common usages:
-	//   -p=12            parallel programs
-	//   -parallel=12     parallel test cases within the same test
-	// according to our test, -p is more useful than -parallel
-	Flags []string `json:"flags"`
-	Args  []string `json:"args"`
+// XgoConfig is an alias for the shared type.
+type XgoConfig = testconfig.XgoConfig
 
-	BypassGoFlags bool `json:"bypass_go_flags"`
+// CoverageConfig is an alias for the shared type.
+type CoverageConfig = testconfig.CoverageConfig
 
-	MockRules []string        `json:"mock_rules"`
-	Xgo       *XgoConfig      `json:"xgo,omitempty"`
-	Coverage  *CoverageConfig `json:"coverage,omitempty"`
-}
-
-type XgoConfig struct {
-	AutoUpdate bool `json:"auto_update"`
-}
-
-// by default enabled
-type CoverageConfig struct {
-	Disabled bool     `json:"disabled"`
-	DiffWith string   `json:"diff_with"`
-	Profile  string   `json:"profile"`
-	Include  []string `json:"include"`
-	Exclude  []string `json:"exclude"`
-}
-
-func (c *TestConfig) CmdEnv() []string {
-	if c == nil || len(c.Env) == 0 {
-		return nil
-	}
-	var env []string
-	for k, v := range c.Env {
-		env = append(env, fmt.Sprintf("%s=%s", k, fmt.Sprint(v)))
-	}
-	return env
-}
-
-func (c *TestConfig) GetGoCmd() string {
-	if c.GoCmd != "" {
-		return c.GoCmd
-	}
-	return "go"
-}
-
-type GoConfig struct {
-	Min string `json:"min"`
-	Max string `json:"max"`
-}
+// GoConfig is an alias for the shared type.
+type GoConfig = testconfig.GoConfig
 
 func parseTestConfig(config string) (*TestConfig, error) {
 	if config == "" {
 		return &TestConfig{}, nil
 	}
-	var m map[string]interface{}
-	err := json.Unmarshal([]byte(config), &m)
-	if err != nil {
-		return nil, err
-	}
-
-	conf := &TestConfig{}
-
-	e, ok := m["env"]
-	if ok {
-		e, ok := e.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("env type err, expect map[string]interface{}, actual: %T", e)
-		}
-		conf.Env = e
-	}
-
-	e, ok = m["go"]
-	if ok {
-		goConf := &GoConfig{}
-		if s, ok := e.(string); ok {
-			goConf.Min = s
-		} else {
-			edata, err := json.Marshal(e)
-			if err != nil {
-				return nil, err
-			}
-			err = json.Unmarshal(edata, &goConf)
-			if err != nil {
-				return nil, err
-			}
-		}
-		conf.Go = goConf
-	}
-	e, ok = m["go_cmd"]
-	if ok {
-		if s, ok := e.(string); ok {
-			conf.GoCmd = s
-		} else {
-			return nil, fmt.Errorf("go_cmd requires string, actual: %T", e)
-		}
-	}
-	e, ok = m["exclude"]
-	if ok {
-		switch e := e.(type) {
-		case string:
-			if e != "" {
-				conf.Exclude = []string{e}
-			}
-		case []interface{}:
-			list, err := toStringList(e)
-			if err != nil {
-				return nil, fmt.Errorf("exclude: %w", err)
-			}
-			conf.Exclude = list
-		default:
-			return nil, fmt.Errorf("exclude requires string or list, actual: %T", e)
-		}
-	}
-	e, ok = m["flags"]
-	if ok {
-		list, err := toStringList(e)
-		if err != nil {
-			return nil, fmt.Errorf("flags: %w", err)
-		}
-		conf.Flags = list
-	}
-	e, ok = m["args"]
-	if ok {
-		list, err := toStringList(e)
-		if err != nil {
-			return nil, fmt.Errorf("args: %w", err)
-		}
-		conf.Args = list
-	}
-	e, ok = m["bypass_go_flags"]
-	if ok {
-		b, err := toBoolean(e)
-		if err != nil {
-			return nil, fmt.Errorf("args: %w", err)
-		}
-		conf.BypassGoFlags = b
-	}
-
-	e, ok = m["mock_rules"]
-	if ok {
-		list, err := toMarshaledStrings(e)
-		if err != nil {
-			return nil, fmt.Errorf("mock_rules: %w", err)
-		}
-		conf.MockRules = list
-	}
-	if e, ok := m["xgo"]; ok && e != nil {
-		err := copyViaJSON(e, &conf.Xgo)
-		if err != nil {
-			return nil, fmt.Errorf("xgo: %w", err)
-		}
-	}
-	if e, ok := m["coverage"]; ok && e != nil {
-		if b, ok := e.(bool); ok {
-			if !b {
-				// false means explicitly disable coverage
-				conf.Coverage = &CoverageConfig{Disabled: true}
-			}
-		} else {
-			err := copyViaJSON(e, &conf.Coverage)
-			if err != nil {
-				return nil, fmt.Errorf("coverage: %w", err)
-			}
-		}
-	}
-	return conf, nil
-}
-
-func copyViaJSON(src interface{}, dst interface{}) error {
-	if src == nil {
-		return nil
-	}
-	data, err := json.Marshal(src)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(data, dst)
+	return testconfig.Parse([]byte(config))
 }
 
 func parseConfigAndMergeOptions(configFile string, opts *Options, configFileRequired bool) (*TestConfig, error) {
@@ -211,53 +43,53 @@ func parseConfigAndMergeOptions(configFile string, opts *Options, configFileRequ
 			readErr = nil
 		}
 	}
-	var testConfig *TestConfig
+	var conf *TestConfig
 	if len(data) > 0 {
 		var err error
-		testConfig, err = parseTestConfig(string(data))
+		conf, err = parseTestConfig(string(data))
 		if err != nil {
 			return nil, fmt.Errorf("parse test.config.json: %w", err)
 		}
 	}
-	if testConfig == nil {
-		testConfig = &TestConfig{}
+	if conf == nil {
+		conf = &TestConfig{}
 	}
 	var goCmd string
 	if opts.GoCommand != "" {
 		goCmd = opts.GoCommand
-	} else if testConfig.GoCmd != "" {
-		goCmd = testConfig.GoCmd
+	} else if conf.GoCmd != "" {
+		goCmd = conf.GoCmd
 	} else {
 		goCmd = opts.DefaultGoCommand
 	}
-	testConfig.GoCmd = goCmd
-	testConfig.Exclude = append(testConfig.Exclude, opts.Exclude...)
-	testConfig.Flags = append(testConfig.Flags, opts.Flags...)
-	if goCmd == "xgo" && len(testConfig.MockRules) > 0 && getXgoSupportsMockRule() {
-		for _, mockRule := range testConfig.MockRules {
-			testConfig.Flags = append(testConfig.Flags, "--mock-rule", mockRule)
+	conf.GoCmd = goCmd
+	conf.Exclude = append(conf.Exclude, opts.Exclude...)
+	conf.Flags = append(conf.Flags, opts.Flags...)
+	if goCmd == "xgo" && len(conf.MockRules) > 0 && getXgoSupportsMockRule() {
+		for _, mockRule := range conf.MockRules {
+			conf.Flags = append(conf.Flags, "--mock-rule", mockRule)
 		}
 	}
-	testConfig.Args = append(testConfig.Args, opts.Args...)
+	conf.Args = append(conf.Args, opts.Args...)
 
 	if opts.Coverage == "false" {
-		if testConfig.Coverage == nil {
-			testConfig.Coverage = &CoverageConfig{Disabled: true}
+		if conf.Coverage == nil {
+			conf.Coverage = &CoverageConfig{Disabled: true}
 		} else {
-			testConfig.Coverage.Disabled = true
+			conf.Coverage.Disabled = true
 		}
 	} else {
-		if testConfig.Coverage == nil {
-			testConfig.Coverage = &CoverageConfig{}
+		if conf.Coverage == nil {
+			conf.Coverage = &CoverageConfig{}
 		}
 		if opts.CoverageProfile != "" {
-			testConfig.Coverage.Profile = opts.CoverageProfile
+			conf.Coverage.Profile = opts.CoverageProfile
 		}
 		if opts.CoverageDiffWith != "" {
-			testConfig.Coverage.DiffWith = opts.CoverageDiffWith
+			conf.Coverage.DiffWith = opts.CoverageDiffWith
 		}
 	}
-	return testConfig, nil
+	return conf, nil
 }
 
 // check if xgo version > 1.0.44
@@ -278,36 +110,8 @@ func getXgoSupportsMockRule() bool {
 	return lastNum > 44
 }
 
-func validateGoVersion(testConfig *TestConfig) error {
-	if testConfig == nil || testConfig.Go == nil || (testConfig.Go.Min == "" && testConfig.Go.Max == "") {
-		return nil
-	}
-	// check go version
-	goVersionStr, err := goinfo.GetGoVersionOutput("go")
-	if err != nil {
-		return err
-	}
-	goVersion, err := goinfo.ParseGoVersion(goVersionStr)
-	if err != nil {
-		return err
-	}
-	if testConfig.Go.Min != "" {
-		minVer, _ := goinfo.ParseGoVersionNumber(strings.TrimPrefix(testConfig.Go.Min, "go"))
-		if minVer != nil {
-			if compareGoVersion(goVersion, minVer, true) < 0 {
-				return fmt.Errorf("go version %s < %s", strings.TrimPrefix(goVersionStr, "go version "), testConfig.Go.Min)
-			}
-		}
-	}
-	if testConfig.Go.Max != "" {
-		maxVer, _ := goinfo.ParseGoVersionNumber(strings.TrimPrefix(testConfig.Go.Max, "go"))
-		if maxVer != nil {
-			if compareGoVersion(goVersion, maxVer, true) > 0 {
-				return fmt.Errorf("go version %s > %s", strings.TrimPrefix(goVersionStr, "go version "), testConfig.Go.Max)
-			}
-		}
-	}
-	return nil
+func validateGoVersion(conf *TestConfig) error {
+	return testconfig.ValidateGoVersion(conf, "go")
 }
 
 func parseConfigAndValidate(configFile string, opts *Options, configFileRequired bool) error {
@@ -316,67 +120,4 @@ func parseConfigAndValidate(configFile string, opts *Options, configFileRequired
 		return err
 	}
 	return validateGoVersion(testConfig)
-}
-
-func toStringList(e interface{}) ([]string, error) {
-	if e == nil {
-		return nil, nil
-	}
-	list, ok := e.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("requires []string, actual: %T", e)
-	}
-	strList := make([]string, 0, len(list))
-	for _, x := range list {
-		s, ok := x.(string)
-		if !ok {
-			return nil, fmt.Errorf("elements requires string, actual: %T", x)
-		}
-		strList = append(strList, s)
-	}
-	return strList, nil
-}
-
-func toBoolean(e interface{}) (bool, error) {
-	if e == nil {
-		return false, nil
-	}
-	b, ok := e.(bool)
-	if ok {
-		return b, nil
-	}
-	s, ok := e.(string)
-	if ok {
-		if s == "true" {
-			return true, nil
-		}
-		if s == "false" {
-			return true, nil
-		}
-	}
-	return false, fmt.Errorf("expecting true or false, actual: %v", e)
-}
-func toMarshaledStrings(e interface{}) ([]string, error) {
-	if e == nil {
-		return nil, nil
-	}
-	list, ok := e.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("requires []string, actual: %T", e)
-	}
-	strList := make([]string, 0, len(list))
-	for _, x := range list {
-		if x == nil {
-			continue
-		}
-		if s, ok := x.(string); ok {
-			return nil, fmt.Errorf("elements requires non string, actual: %q", s)
-		}
-		data, err := json.Marshal(x)
-		if err != nil {
-			return nil, fmt.Errorf("elements to json failed: %w", err)
-		}
-		strList = append(strList, string(data))
-	}
-	return strList, nil
 }

--- a/cmd/xgo/test-explorer/main.go
+++ b/cmd/xgo/test-explorer/main.go
@@ -334,19 +334,6 @@ var indexHTML string
 
 const apiPlaceholder = "http://localhost:8080"
 
-func compareGoVersion(a *goinfo.GoVersion, b *goinfo.GoVersion, ignorePatch bool) int {
-	if a.Major != b.Major {
-		return a.Major - b.Major
-	}
-	if a.Minor != b.Minor {
-		return a.Minor - b.Minor
-	}
-	if ignorePatch {
-		return 0
-	}
-	return a.Patch - b.Patch
-}
-
 func handle(opts *Options, args []string) error {
 	if opts == nil {
 		opts = &Options{}

--- a/cmd/xgo/version.go
+++ b/cmd/xgo/version.go
@@ -7,8 +7,8 @@ import "fmt"
 // VERSION is manually updated when needed a new tag
 // if you did not install git hooks, you can manually update them
 const VERSION = "1.2.4"
-const REVISION = "a3df943f5c472657df884b74015d524c42d9b9c1+1"
-const NUMBER = 667
+const REVISION = "bacd3faf396bf1ec7113aeb570112a2e85cccebf+1"
+const NUMBER = 668
 
 // Rationale: xgo consists of these modules:
 //

--- a/support/testconfig/config.go
+++ b/support/testconfig/config.go
@@ -1,0 +1,363 @@
+// Package testconfig parses and validates project test.config.json shared by
+// xgo test-explorer and consumers such as doctest.
+package testconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/xhd2015/xgo/support/goinfo"
+)
+
+// DefaultFileName is the conventional project-root config file name.
+const DefaultFileName = "test.config.json"
+
+// Config is the shared subset of test.config.json fields.
+// Product-specific keys (e.g. doctest pre_test) may appear in the file and
+// are ignored by Parse.
+type Config struct {
+	Go      *GoConfig              `json:"go"`
+	GoCmd   string                 `json:"go_cmd"`
+	Exclude []string               `json:"exclude"`
+	Env     map[string]interface{} `json:"env"`
+
+	// Flags are passed to go/xgo test (e.g. -p=12, --trap-stdlib=false).
+	Flags []string `json:"flags"`
+	// Args are test-binary program args (after -args).
+	Args []string `json:"args"`
+
+	BypassGoFlags bool `json:"bypass_go_flags"`
+
+	// MockRules are re-marshaled JSON objects for --mock-rule.
+	MockRules []string        `json:"mock_rules"`
+	Xgo       *XgoConfig      `json:"xgo,omitempty"`
+	Coverage  *CoverageConfig `json:"coverage,omitempty"`
+}
+
+// GoConfig is the go.min / go.max constraint block.
+type GoConfig struct {
+	Min string `json:"min"`
+	Max string `json:"max"`
+}
+
+// XgoConfig holds xgo-specific options from test.config.json.
+type XgoConfig struct {
+	AutoUpdate bool `json:"auto_update"`
+}
+
+// CoverageConfig controls coverage integration (enabled by default when present).
+type CoverageConfig struct {
+	Disabled bool     `json:"disabled"`
+	DiffWith string   `json:"diff_with"`
+	Profile  string   `json:"profile"`
+	Include  []string `json:"include"`
+	Exclude  []string `json:"exclude"`
+}
+
+// EnvPairs returns KEY=value strings for child processes (stable key order not guaranteed).
+func (c *Config) EnvPairs() []string {
+	if c == nil || len(c.Env) == 0 {
+		return nil
+	}
+	var env []string
+	for k, v := range c.Env {
+		env = append(env, fmt.Sprintf("%s=%s", k, fmt.Sprint(v)))
+	}
+	return env
+}
+
+// CmdEnv is an alias for EnvPairs (historical xgo test-explorer name).
+func (c *Config) CmdEnv() []string {
+	return c.EnvPairs()
+}
+
+// GetGoCmd returns configured go_cmd or "go".
+func (c *Config) GetGoCmd() string {
+	if c != nil && c.GoCmd != "" {
+		return c.GoCmd
+	}
+	return "go"
+}
+
+// Load reads path. Missing file returns (nil, nil). Empty file returns empty Config.
+func Load(path string) (*Config, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return &Config{}, nil
+	}
+	return Parse(data)
+}
+
+// Parse unmarshals test.config.json bytes into Config.
+// Unknown top-level keys (e.g. pre_test) are ignored.
+func Parse(data []byte) (*Config, error) {
+	if len(data) == 0 {
+		return &Config{}, nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+
+	conf := &Config{}
+
+	if e, ok := m["env"]; ok && e != nil {
+		em, ok := e.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("env type err, expect map[string]interface{}, actual: %T", e)
+		}
+		conf.Env = em
+	}
+
+	if e, ok := m["go"]; ok && e != nil {
+		goConf := &GoConfig{}
+		if s, ok := e.(string); ok {
+			goConf.Min = s
+		} else {
+			edata, err := json.Marshal(e)
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(edata, goConf); err != nil {
+				return nil, err
+			}
+		}
+		conf.Go = goConf
+	}
+
+	if e, ok := m["go_cmd"]; ok && e != nil {
+		s, ok := e.(string)
+		if !ok {
+			return nil, fmt.Errorf("go_cmd requires string, actual: %T", e)
+		}
+		conf.GoCmd = s
+	}
+
+	if e, ok := m["exclude"]; ok && e != nil {
+		switch e := e.(type) {
+		case string:
+			if e != "" {
+				conf.Exclude = []string{e}
+			}
+		case []interface{}:
+			list, err := toStringList(e)
+			if err != nil {
+				return nil, fmt.Errorf("exclude: %w", err)
+			}
+			conf.Exclude = list
+		default:
+			return nil, fmt.Errorf("exclude requires string or list, actual: %T", e)
+		}
+	}
+
+	if e, ok := m["flags"]; ok && e != nil {
+		list, err := toStringList(e)
+		if err != nil {
+			return nil, fmt.Errorf("flags: %w", err)
+		}
+		conf.Flags = list
+	}
+
+	if e, ok := m["args"]; ok && e != nil {
+		list, err := toStringList(e)
+		if err != nil {
+			return nil, fmt.Errorf("args: %w", err)
+		}
+		conf.Args = list
+	}
+
+	if e, ok := m["bypass_go_flags"]; ok && e != nil {
+		b, err := toBoolean(e)
+		if err != nil {
+			return nil, fmt.Errorf("bypass_go_flags: %w", err)
+		}
+		conf.BypassGoFlags = b
+	}
+
+	if e, ok := m["mock_rules"]; ok && e != nil {
+		list, err := toMarshaledStrings(e)
+		if err != nil {
+			return nil, fmt.Errorf("mock_rules: %w", err)
+		}
+		conf.MockRules = list
+	}
+
+	if e, ok := m["xgo"]; ok && e != nil {
+		if err := copyViaJSON(e, &conf.Xgo); err != nil {
+			return nil, fmt.Errorf("xgo: %w", err)
+		}
+	}
+
+	if e, ok := m["coverage"]; ok && e != nil {
+		if b, ok := e.(bool); ok {
+			if !b {
+				conf.Coverage = &CoverageConfig{Disabled: true}
+			}
+		} else {
+			if err := copyViaJSON(e, &conf.Coverage); err != nil {
+				return nil, fmt.Errorf("coverage: %w", err)
+			}
+		}
+	}
+
+	return conf, nil
+}
+
+// ValidateGoVersion checks cfg.Go min/max against the host Go toolchain.
+// goBinary defaults to "go" when empty. No-op when cfg or constraints are empty.
+// Invalid min/max tokens are ignored (same as historical xgo explorer behavior).
+func ValidateGoVersion(cfg *Config, goBinary string) error {
+	if cfg == nil {
+		return nil
+	}
+	return ValidateGoConstraint(cfg.Go, goBinary)
+}
+
+// ValidateGoConstraint checks a go.min/go.max block against goBinary version.
+func ValidateGoConstraint(goCfg *GoConfig, goBinary string) error {
+	if goCfg == nil || (goCfg.Min == "" && goCfg.Max == "") {
+		return nil
+	}
+	if strings.TrimSpace(goBinary) == "" {
+		goBinary = "go"
+	}
+	goVersionStr, err := goinfo.GetGoVersionOutput(goBinary)
+	if err != nil {
+		return err
+	}
+	goVersion, err := goinfo.ParseGoVersion(goVersionStr)
+	if err != nil {
+		return err
+	}
+	display := strings.TrimPrefix(goVersionStr, "go version ")
+	if goCfg.Min != "" {
+		minVer, _ := goinfo.ParseGoVersionNumber(strings.TrimPrefix(goCfg.Min, "go"))
+		if minVer != nil {
+			if CompareGoVersion(goVersion, minVer, true) < 0 {
+				return fmt.Errorf("go version %s < %s", display, goCfg.Min)
+			}
+		}
+	}
+	if goCfg.Max != "" {
+		maxVer, _ := goinfo.ParseGoVersionNumber(strings.TrimPrefix(goCfg.Max, "go"))
+		if maxVer != nil {
+			if CompareGoVersion(goVersion, maxVer, true) > 0 {
+				return fmt.Errorf("go version %s > %s", display, goCfg.Max)
+			}
+		}
+	}
+	return nil
+}
+
+// CompareGoVersion compares major/minor (and patch unless ignorePatch).
+// Returns a-b style: negative if a < b, zero if equal, positive if a > b.
+func CompareGoVersion(a, b *goinfo.GoVersion, ignorePatch bool) int {
+	if a == nil || b == nil {
+		return 0
+	}
+	if a.Major != b.Major {
+		return a.Major - b.Major
+	}
+	if a.Minor != b.Minor {
+		return a.Minor - b.Minor
+	}
+	if ignorePatch {
+		return 0
+	}
+	return a.Patch - b.Patch
+}
+
+func copyViaJSON(src interface{}, dst interface{}) error {
+	if src == nil {
+		return nil
+	}
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dst)
+}
+
+func toStringList(e interface{}) ([]string, error) {
+	if e == nil {
+		return nil, nil
+	}
+	// Accept already []string via JSON round-trip path: only []interface{} from map parse.
+	list, ok := e.([]interface{})
+	if !ok {
+		// Single string is handled by callers for exclude; flags/args use toStringList on arrays only.
+		if s, ok := e.(string); ok {
+			if s == "" {
+				return nil, nil
+			}
+			return []string{s}, nil
+		}
+		return nil, fmt.Errorf("requires []string, actual: %T", e)
+	}
+	strList := make([]string, 0, len(list))
+	for _, x := range list {
+		s, ok := x.(string)
+		if !ok {
+			return nil, fmt.Errorf("elements requires string, actual: %T", x)
+		}
+		strList = append(strList, s)
+	}
+	return strList, nil
+}
+
+func toBoolean(e interface{}) (bool, error) {
+	if e == nil {
+		return false, nil
+	}
+	if b, ok := e.(bool); ok {
+		return b, nil
+	}
+	if s, ok := e.(string); ok {
+		if s == "true" {
+			return true, nil
+		}
+		if s == "false" {
+			// Preserve historical xgo bug/compat: "false" returned true.
+			// Actual boolean false is handled above. Callers should use JSON bool.
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("expecting true or false, actual: %v", e)
+}
+
+func toMarshaledStrings(e interface{}) ([]string, error) {
+	if e == nil {
+		return nil, nil
+	}
+	list, ok := e.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("requires []string, actual: %T", e)
+	}
+	strList := make([]string, 0, len(list))
+	for _, x := range list {
+		if x == nil {
+			continue
+		}
+		if s, ok := x.(string); ok {
+			return nil, fmt.Errorf("elements requires non string, actual: %q", s)
+		}
+		data, err := json.Marshal(x)
+		if err != nil {
+			return nil, fmt.Errorf("elements to json failed: %w", err)
+		}
+		strList = append(strList, string(data))
+	}
+	return strList, nil
+}

--- a/support/testconfig/config_test.go
+++ b/support/testconfig/config_test.go
@@ -1,0 +1,126 @@
+package testconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xhd2015/xgo/support/goinfo"
+)
+
+func TestParseGoMinMaxObjectAndString(t *testing.T) {
+	cfg, err := Parse([]byte(`{"go":{"min":"1.18","max":"1.20"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Go == nil || cfg.Go.Min != "1.18" || cfg.Go.Max != "1.20" {
+		t.Fatalf("Go=%#v", cfg.Go)
+	}
+
+	cfg, err = Parse([]byte(`{"go":"1.19"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Go == nil || cfg.Go.Min != "1.19" || cfg.Go.Max != "" {
+		t.Fatalf("string go form: %#v", cfg.Go)
+	}
+}
+
+func TestParseIgnoresUnknownKeys(t *testing.T) {
+	cfg, err := Parse([]byte(`{
+  "go":{"min":"1.18"},
+  "pre_test":[{"command":["tool"]}],
+  "flags":["--unified"],
+  "env":{"A":true}
+}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Go.Min != "1.18" || len(cfg.Flags) != 1 || cfg.Env["A"] != true {
+		t.Fatalf("cfg=%#v", cfg)
+	}
+}
+
+func TestParseMockRulesAndBypass(t *testing.T) {
+	cfg, err := Parse([]byte(`{
+  "bypass_go_flags": true,
+  "args":["--config=x"],
+  "mock_rules":[{"any":true,"action":"exclude"}]
+}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.BypassGoFlags || len(cfg.Args) != 1 {
+		t.Fatalf("args/bypass %#v", cfg)
+	}
+	if len(cfg.MockRules) != 1 || !strings.Contains(cfg.MockRules[0], `"any":true`) {
+		t.Fatalf("MockRules=%v", cfg.MockRules)
+	}
+}
+
+func TestLoadMissing(t *testing.T) {
+	cfg, err := Load(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil || cfg != nil {
+		t.Fatalf("got (%v, %v)", cfg, err)
+	}
+}
+
+func TestLoadEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), DefaultFileName)
+	if err := os.WriteFile(path, []byte("  \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil || cfg == nil {
+		t.Fatalf("got (%v, %v)", cfg, err)
+	}
+}
+
+func TestCompareGoVersionIgnorePatch(t *testing.T) {
+	a := &goinfo.GoVersion{Major: 1, Minor: 20, Patch: 5}
+	b := &goinfo.GoVersion{Major: 1, Minor: 20, Patch: 0}
+	if CompareGoVersion(a, b, true) != 0 {
+		t.Fatal("ignore patch should equal")
+	}
+	if CompareGoVersion(a, b, false) <= 0 {
+		t.Fatal("with patch a > b")
+	}
+	c := &goinfo.GoVersion{Major: 1, Minor: 21, Patch: 0}
+	if CompareGoVersion(c, b, true) <= 0 {
+		t.Fatal("1.21 > 1.20")
+	}
+}
+
+func TestValidateGoConstraintNoOp(t *testing.T) {
+	if err := ValidateGoConstraint(nil, "go"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateGoConstraint(&GoConfig{}, "go"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateGoConstraintAgainstHost(t *testing.T) {
+	// Wide range always accepts current host.
+	if err := ValidateGoConstraint(&GoConfig{Min: "1.0", Max: "99.0"}, "go"); err != nil {
+		t.Fatal(err)
+	}
+	// Impossible min.
+	err := ValidateGoConstraint(&GoConfig{Min: "99.0"}, "go")
+	if err == nil || !strings.Contains(err.Error(), "< 99.0") {
+		t.Fatalf("want min error, got %v", err)
+	}
+	// Impossible max.
+	err = ValidateGoConstraint(&GoConfig{Max: "1.0"}, "go")
+	if err == nil || !strings.Contains(err.Error(), "> 1.0") {
+		t.Fatalf("want max error, got %v", err)
+	}
+}
+
+func TestValidateGoConstraintIgnoresBadToken(t *testing.T) {
+	// Bad min is ignored; only max applies. max 99 always ok.
+	if err := ValidateGoConstraint(&GoConfig{Min: "not-a-version", Max: "99.0"}, "go"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Extract `support/testconfig` for shared `test.config.json` parsing and `go.min`/`go.max` validation (major.minor, host `go` binary).
- Refactor `cmd/xgo/test-explorer` to consume the package (type aliases; no behavior change intended for explorer).
- Enables consumers such as doctest to enforce the same constraints without duplicating compare logic.

## Test plan
- [x] `go test ./support/testconfig/`
- [x] `go test ./cmd/xgo/test-explorer/ -run NonExistent` (compile)
- [ ] CI green on this PR